### PR TITLE
Fix patch call in README more

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ namelist patch and apply it to a target file using the ``patch`` function:
 .. code:: python
 
    patch_nml = {'config_nml': {'visc': 1e-6}}
-   f90nml.patch('sample.nml', 'new_sample.nml', patch_nml)
+   f90nml.patch('sample.nml', patch_nml, 'new_sample.nml')
 
 
 Installation


### PR DESCRIPTION
Ah, sorry I didn't catch this in the last PR - the arguments are also in the wrong order in the README.