### PR TITLE
Fix to allow assigning dicts to namelist groups

### DIFF
--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -58,8 +58,8 @@ class Namelist(OrderedDict):
         return super(Namelist, self).__getitem__(key.lower())
 
     def __setitem__(self, key, value):
-        # if passed a dict, convert it to a Namelist
-        if isinstance(value, dict):
+        # if the value is dict-like, but not a Namelist, convert it to a Namelist
+        if isinstance(value, dict) and not isinstance(value, Namelist):
             value = Namelist(value)
         super(Namelist, self).__setitem__(key.lower(), value)
 

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -58,6 +58,9 @@ class Namelist(OrderedDict):
         return super(Namelist, self).__getitem__(key.lower())
 
     def __setitem__(self, key, value):
+        # if passed a dict, convert it to a Namelist
+        if isinstance(value, dict):
+            value = Namelist(value)
         super(Namelist, self).__setitem__(key.lower(), value)
 
     # Format configuration

--- a/test/test_f90nml.py
+++ b/test/test_f90nml.py
@@ -323,6 +323,9 @@ class Test(unittest.TestCase):
                 )
             }
 
+        if os.path.isfile('tmp.nml'):
+            os.remove('tmp.nml')
+
     # Support functions
     def assert_file_equal(self, source_fname, target_fname):
         with open(source_fname) as source:
@@ -678,6 +681,15 @@ class Test(unittest.TestCase):
 
     def test_dict_write(self):
         self.assert_write(self.types_nml, 'types_dict.nml')
+
+    def test_dict_assign(self):
+        test_nml = f90nml.Namelist()
+        test_nml['dict_group'] = {'a': 1, 'b':2}
+        try:
+            test_nml.write('tmp.nml')
+        finally:
+            os.remove('tmp.nml')
+
 
     if has_numpy:
         def test_numpy_write(self):


### PR DESCRIPTION
In version 0.19 it was possible to assign a dict to a namelist group and
write it out.  This fix allows the same behaviour in 0.21.

An example:

```python
import f90nml

namelist = f90nml.Namelist()

namelist['main_nml'] = {
     'days'   : 30,
     'hours'  : 0,
     'minutes': 0,
     'seconds': 0,
     'dt':720,
}

namelist.write('base.nml')
```

This used to work in version 0.19, now doesn't in version 0.21 (error message below).  PR fixes this by casting `dict` to `Namelist` when assigned to a key in the namelist.

```
$ python nml_test.py
Traceback (most recent call last):
  File "nml_test.py", line 15, in <module>
    namelist.write('base.nml')
  File "/f90nml/f90nml/namelist.py", line 232, in write
    self.write_nmlgrp(grp_name, grp_vars, nml_file)
  File "/f90nml/f90nml/namelist.py", line 251, in write_nmlgrp
    v_start = grp_vars.start_index.get(v_name, None)
AttributeError: 'dict' object has no attribute 'start_index'
```