### PR TITLE
Added Namelist.update_values(namelist_fragment) method.

### DIFF
--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -112,6 +112,16 @@ class Namelist(OrderedDict):
             raise TypeError('Indentation must be specified by string or space '
                             'width.')
 
+    def update_values(self, namelist):
+        """Update the namelist from another partial or full namelist.
+
+        This is different from `Namelist.update` as it does not replace
+        namelist sections, instead it performs an update on the section."""
+        for sec in namelist:
+            if sec not in self:
+                self[sec] = Namelist()
+            self[sec].update(namelist[sec])
+
     # Terminal comma
     @property
     def end_comma(self):

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -112,15 +112,15 @@ class Namelist(OrderedDict):
             raise TypeError('Indentation must be specified by string or space '
                             'width.')
 
-    def update_values(self, namelist):
+    def patch(self, nml_patch):
         """Update the namelist from another partial or full namelist.
 
         This is different from `Namelist.update` as it does not replace
         namelist sections, instead it performs an update on the section."""
-        for sec in namelist:
+        for sec in nml_patch:
             if sec not in self:
                 self[sec] = Namelist()
-            self[sec].update(namelist[sec])
+            self[sec].update(nml_patch[sec])
 
     # Terminal comma
     @property

--- a/test/test_f90nml.py
+++ b/test/test_f90nml.py
@@ -701,6 +701,24 @@ class Test(unittest.TestCase):
         test_nml = f90nml.read('winfmt.nml')
         self.assertEqual(self.winfmt_nml, test_nml)
 
+    def test_update_values(self):
+        nml = f90nml.Namelist({
+            'a_nml': {
+                'x': 1,
+                'y': 2,
+            }
+        })
+        # check overwriting values
+        nml.update_values({'a_nml': {'x': 3}})
+        self.assertEqual(nml['a_nml']['x'], 3)
+        self.assertEqual(nml['a_nml']['y'], 2)
+        # check appending values doesn't remove previous
+        nml.update_values({'a_nml': {'z': 5}})
+        self.assertEqual(nml['a_nml']['x'], 3)
+        self.assertEqual(nml['a_nml']['y'], 2)
+        self.assertEqual(nml['a_nml']['z'], 5)
+
+
     if has_numpy:
         def test_numpy_write(self):
             self.assert_write(self.numpy_nml, 'numpy_types.nml')

--- a/test/test_f90nml.py
+++ b/test/test_f90nml.py
@@ -717,6 +717,14 @@ class Test(unittest.TestCase):
         self.assertEqual(nml['a_nml']['x'], 3)
         self.assertEqual(nml['a_nml']['y'], 2)
         self.assertEqual(nml['a_nml']['z'], 5)
+        # check adding a new section also works
+        nml.update_values({
+            'b_nml': {'q': 33},
+            'a_nml': {'z': 4}
+        })
+        self.assertEqual(nml['a_nml']['z'], 4)
+        self.assertEqual(nml['b_nml']['q'], 33)
+        self.assertRaises(KeyError, nml['b_nml'].__getitem__, 'z')
 
 
     if has_numpy:

--- a/test/test_f90nml.py
+++ b/test/test_f90nml.py
@@ -701,7 +701,7 @@ class Test(unittest.TestCase):
         test_nml = f90nml.read('winfmt.nml')
         self.assertEqual(self.winfmt_nml, test_nml)
 
-    def test_update_values(self):
+    def test_namelist_patch(self):
         nml = f90nml.Namelist({
             'a_nml': {
                 'x': 1,
@@ -709,16 +709,16 @@ class Test(unittest.TestCase):
             }
         })
         # check overwriting values
-        nml.update_values({'a_nml': {'x': 3}})
+        nml.patch({'a_nml': {'x': 3}})
         self.assertEqual(nml['a_nml']['x'], 3)
         self.assertEqual(nml['a_nml']['y'], 2)
         # check appending values doesn't remove previous
-        nml.update_values({'a_nml': {'z': 5}})
+        nml.patch({'a_nml': {'z': 5}})
         self.assertEqual(nml['a_nml']['x'], 3)
         self.assertEqual(nml['a_nml']['y'], 2)
         self.assertEqual(nml['a_nml']['z'], 5)
         # check adding a new section also works
-        nml.update_values({
+        nml.patch({
             'b_nml': {'q': 33},
             'a_nml': {'z': 4}
         })


### PR DESCRIPTION
This is a function that I use on my own code - it is useful for performing parameter sweeps based on a namelist built directly out of a combination of python dictionaries.  It allows a base namelist to be updated with new values in some sections, without overwriting the entire section as `Namelist.update` does.
For example:
```
nml = Namelist({
    'main_nml': {
        'dt': 500,
        'steps': 1000,
        'initT': 100
    }
})
nml.update_values({'main_nml': {'initT': 200}})
```
Will update the value of `main_nml.initT` but other values will retain their original values. `nml.update` would replace the entire section, losing the values of `dt` and `steps`.

I think this is similar to the functionality of `f90nml.patch` but doesn't require a namelist file to first be written to disk.

