### PR TITLE
New feature: Parse namelist file with leading comments (prior to ampersand sign)

### DIFF
--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -127,34 +127,54 @@ class Parser(object):
             ...
           
            This function trims the first two lines for future parsing
+           input: nml_file object
+           output: a list of filtered string. If no line starting with & is found, return empty list
         """
         foundAmpersand = False
         local_nml = []
- 
+
         for idx,val in enumerate(nml_file):
             if val.lstrip().startswith('&'):
                 foundAmpersand = True
-            
+
             if foundAmpersand:
                 local_nml.append(val)
-        #end for
-    
-        if not foundAmpersand:
-          return []
-        else:
-          return local_nml
+
+        return local_nml
+
 
     def readstream(self, nml_file, nml_patch):
         """Parse an input stream containing a Fortran namelist."""
 
         tokenizer = Tokenizer()
         f90lex = []
-
+        
         nml_file_preprocessed = self.filter_preprocess(nml_file)
+
         for line in nml_file_preprocessed:
             toks = tokenizer.parse(line)
+            while tokenizer.prior_delim:
+                new_toks = tokenizer.parse(next(nml_file))
+
+                # Skip empty lines
+                if not new_toks:
+                    continue
+
+                # The tokenizer always pre-tokenizes the whitespace (leftover
+                # behaviour from Fortran source parsing) so this must be added
+                # manually.
+                if new_toks[0].isspace():
+                    toks[-1] += new_toks.pop(0)
+
+                # Append the rest of the string (if present)
+                if new_toks:
+                    toks[-1] += new_toks[0]
+
+                    # Attach the rest of the tokens
+                    toks.extend(new_toks[1:])
+
             toks.append('\n')
-            f90lex.extend(toks)
+            f90lex.extend(toks) 
 
         self.tokens = iter(f90lex)
 


### PR DESCRIPTION
Sample Fortran namelist
----
Some comments
 &efitin
  scrape=0      abc=0           def=0           defg=0
  abcd=0.0       
/

----

f90nml fails to parse this namelist file due to the first line. This patch helps me overcome this problem