### PR TITLE
py37 travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: python
+group: travis_latest
+dist: xenial
+
+git:
+  depth: 25
+  quiet: true
+
 python:
-    - "2.6"
-    - "2.7"
-    - "3.3"
-    - "3.4"
-    - "3.5"
-    - "3.6"
-    - "pypy"
-    - "pypy3"
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+    - 3.7
+    - pypy
+    - pypy3
 install:
     - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then
         pip install ordereddict; fi
@@ -19,4 +25,3 @@ script:
 after_success:
     - coverage report -m
     - coveralls
-sudo: False


### PR DESCRIPTION
Add Python 3.7 to Travis-CI. 

Is there a particular need for Python 2.6 / 3.3? The market share of these is ~0 and there are significant performance, testing and style improvements that can be made if Python 2.6 / 3.3 are dropped