### PR TITLE
add optional column alignment in write

### DIFF
--- a/f90nml/__init__.py
+++ b/f90nml/__init__.py
@@ -47,7 +47,7 @@ def reads(nml_string):
     return parser.reads(nml_string)
 
 
-def write(nml, nml_path, force=False, sort=False):
+def write(nml, nml_path, force=False, sort=False, colwidth=0):
     """Save a namelist to disk using either a file object or its file path.
 
     File object usage:
@@ -79,7 +79,7 @@ def write(nml, nml_path, force=False, sort=False):
     else:
         nml_in = nml
 
-    nml_in.write(nml_path, force=force, sort=sort)
+    nml_in.write(nml_path, force=force, sort=sort, colwidth=colwidth)
 
 
 def patch(nml_path, nml_patch, out_path=None):


### PR DESCRIPTION
Hi @marshallward, just wondering if you'd consider this PR. 

It adds an optional `colwidth` argument to `write` and associated functions that sets a minimum column width between the start of a variable name and the start of " = " in the output.  This can make output much more readable, e.g. https://github.com/COSIMA/01deg_jra55_iaf/blob/ak-dev/ice/cice_in.nml

It uses `ljust`, so if a variable name is too long it will simply push the " = " along a bit more (i.e. the variable name won't be trimmed - see `history_deflate_level` in the link). The usual behaviour is retained with the default `colwidth=0`. 