### PR TITLE
Compress

### DIFF
--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -79,7 +79,7 @@ class Namelist(OrderedDict):
         self._float_format = ''
         self._logical_repr = {False: '.false.', True: '.true.'}
         self._index_spacing = False
-        self._repeat = False
+        self._repeat_counter = False
 
         # Namelist group spacing flag
         self._newline = False
@@ -412,20 +412,20 @@ class Namelist(OrderedDict):
         self._start_index = value
 
     @property
-    def repeat(self):
+    def repeat_counter(self):
         r"""Set whether the namelist should be written with repeats,
         i.e. whether arrays should be written as 1, 2, 2 or as 1, 2*2
 
         :type: ``bool``
         :default: ``False``
         """
-        return self._repeat
+        return self._repeat_counter
 
-    @repeat.setter
-    def repeat(self, value):
+    @repeat_counter.setter
+    def repeat_counter(self, value):
         """Set whether array output should be done in repeat form."""
         if isinstance(value, bool):
-            self._repeat = value
+            self._repeat_counter = value
         else:
             raise TypeError(r"repeat must be of type ``bool``")
 
@@ -638,7 +638,7 @@ class Namelist(OrderedDict):
             val_strs = []
             val_line = v_header
 
-            if self._repeat:
+            if self._repeat_counter:
                 v_values = list(
                     self.RepeatValue(len(list(x)), val)
                     for val, x in itertools.groupby(v_values)

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -653,9 +653,10 @@ class Namelist(OrderedDict):
                         if i_val < len(v_values) - 1 or self.end_comma:
                             val_line += ', '
 
+                # Line break
                 if len(val_line) >= column_width:
-                    val_strs.append(val_line.rstrip())
-                    val_line = ' ' * len(v_header)
+                    val_strs.append(val_line.rstrip())  # Append current line to list of lines
+                    val_line = ' ' * len(v_header)      # Start new line with space corresponding to header
 
             # Append any remaining values
             if val_line and not val_line.isspace():

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -409,9 +409,9 @@ class Namelist(OrderedDict):
 
     @property
     def compressed(self):
-        r"""Set whether the namelist should be written compressed, 
+        r"""Set whether the namelist should be written compressed,
         i.e. whether arrays should be written as 1, 2, 2 or as 1, 2*2
-        
+
         :type: ``bool``
         :default: ``False``
         """
@@ -636,7 +636,7 @@ class Namelist(OrderedDict):
 
             if self._compressed:
                 v_values = self._compress(v_values)
-            
+
             for i_val, v_val in enumerate(v_values):
                 # Increase column width if the header exceeds this value
                 if len(v_header) >= self.column_width:
@@ -681,8 +681,10 @@ class Namelist(OrderedDict):
 
                 # Line break
                 if len(val_line) >= column_width:
-                    val_strs.append(val_line.rstrip())  # Append current line to list of lines
-                    val_line = ' ' * len(v_header)      # Start new line with space corresponding to header
+                    # Append current line to list of lines
+                    val_strs.append(val_line.rstrip())
+                    # Start new line with space corresponding to header
+                    val_line = ' ' * len(v_header)
 
             # Append any remaining values
             if val_line and not val_line.isspace():
@@ -811,11 +813,8 @@ class Namelist(OrderedDict):
         """
         # Assertions that the input is in the format we want: [n, v]
         # Where n is the number of successive values of v
-        try:
-            n, v = value
-            assert isinstance(n, int)
-        except:
-            raise TypeError("for the compressed representation we need a len-2 list of n, v")
+        n, v = value
+        assert isinstance(n, int)
         if value[0] == 1:
             return self._f90repr(value[1])
         else:
@@ -824,8 +823,10 @@ class Namelist(OrderedDict):
     def _compress(self, values):
         """ (list) -> (list of list(int, *))
 
-        Returns a compressed list, where each element is a list of two elements:
-        The first is the number of successive identical elements in the input list `values`,
+        Returns a compressed list, where each element is a list of two
+        elements:
+        The first is the number of successive identical elements in the
+        input list `values`,
         the second is the element.
 
         >>> _compress(Namelist, [1, 1, 1, 2, 1, 1])
@@ -833,13 +834,13 @@ class Namelist(OrderedDict):
         """
         if len(values) < 1:
             return []
-        
+
         last_value = values[0]
         c_values = [[1, last_value]]
 
         if len(values) == 1:
             return c_values
-        
+
         for value in values[1:]:
             if value == last_value:
                 c_values[-1][0] += 1
@@ -847,7 +848,6 @@ class Namelist(OrderedDict):
                 c_values.append([1, value])
                 last_value = value
         return c_values
-
 
 
 def is_nullable_list(val, vtype):

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -26,8 +26,6 @@ except NameError:
     basestring = str    # Python 3.x
 
 
-
-
 class Namelist(OrderedDict):
     """Representation of Fortran namelist in a Python environment.
 
@@ -642,7 +640,8 @@ class Namelist(OrderedDict):
 
             if self._repeat:
                 v_values = list(
-                    self.RepeatValue(len(list(x)), val) for val, x in itertools.groupby(v_values)
+                    self.RepeatValue(len(list(x)), val)
+                    for val, x in itertools.groupby(v_values)
                 )
             for i_val, v_val in enumerate(v_values):
                 # Increase column width if the header exceeds this value
@@ -783,8 +782,8 @@ class Namelist(OrderedDict):
         if value.repeats == 1:
             return self._f90repr(value.value)
         else:
-            return "{0}*{1}".format(value.repeats, 
-                self._f90repr(value.value))
+            return "{0}*{1}".format(value.repeats,
+                                    self._f90repr(value.value))
 
     def _f90bool(self, value):
         """Return a Fortran 90 representation of a logical value."""

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -831,8 +831,7 @@ class Namelist(OrderedDict):
         >>> _compress(Namelist, [1, 1, 1, 2, 1, 1])
         [[3, 1], [1, 2], [2, 1]]
         """
-        if len(values) < 1:
-            return []
+        assert len(values) > 0
         last_value = values[0]
         c_values = [[1, last_value]]
 

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -1209,25 +1209,25 @@ class Test(unittest.TestCase):
 
         f90nml.cli.has_yaml = orig_has_yaml
 
-    def test_check_compressed_flag(self):
+    def test_check_repeat_flag(self):
         nml = f90nml.Namelist()
-        self.assertFalse(nml.compressed)
+        self.assertFalse(nml.repeat)
 
-    def test_set_compressed_flag(self):
+    def test_set_repeat_flag(self):
         nml = f90nml.Namelist()
-        nml.compressed = True
-        self.assertTrue(nml.compressed)
+        nml.repeat = True
+        self.assertTrue(nml.repeat)
 
-    def test_set_compressed_flag_incorrect(self):
+    def test_set_repeat_flag_incorrect(self):
         nml = f90nml.Namelist()
         with self.assertRaises(TypeError):
-            nml.compressed = 'Hello'
+            nml.repeat = 'Hello'
 
     # TODO fails in _var_strings 
-    # def test_compressed_empty(self):
+    # def test_repeat_empty(self):
         # nml_dict = {'a':{'b' : []}}
         # nml = f90nml.Namelist(nml_dict)
-        # nml.compressed = True
+        # nml.repeat = True
         # out = StringIO()
         # print(nml, file=out)
         # out.seek(0)
@@ -1235,10 +1235,10 @@ class Test(unittest.TestCase):
         # line2 = out.readline()
         # self.assertEqual(line2.lstrip(), 'b = 1, 2, 3\n')
 
-    def test_compressed_single(self):
+    def test_repeat_single(self):
         nml_dict = {'a':{'b' : [1]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1246,10 +1246,10 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), 'b = 1\n')
 
-    def test_compressed_no_consecutive(self):
+    def test_repeat_no_consecutive(self):
         nml_dict = {'a':{'b' : [1, 2, 3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1257,10 +1257,10 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), 'b = 1, 2, 3\n')
 
-    def test_compressed_middle_consecutive(self):
+    def test_repeat_middle_consecutive(self):
         nml_dict = {'a':{'b' : [1, 2, 2, 3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1268,10 +1268,10 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), 'b = 1, 2*2, 3\n')
 
-    def test_compressed_beginning_consecutive(self):
+    def test_repeat_beginning_consecutive(self):
         nml_dict = {'a':{'b' : [1, 1, 2, 3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1279,10 +1279,10 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), 'b = 2*1, 2, 3\n')
 
-    def test_compressed_end_consecutive(self):
+    def test_repeat_end_consecutive(self):
         nml_dict = {'a':{'b' : [1, 2, 3, 3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1290,10 +1290,10 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), 'b = 1, 2, 2*3\n')
 
-    def test_compressed_consecutive_repeating(self):
+    def test_repeat_consecutive_repeating(self):
         nml_dict = {'a':{'b' : [1, 1, 2, 3, 1, 1, 1]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1301,10 +1301,10 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), 'b = 2*1, 2, 3, 3*1\n')
 
-    def test_compressed_all_repeating(self):
+    def test_repeat_all_repeating(self):
         nml_dict = {'a':{'b' : [1, 1, 1, 1, 1]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1312,10 +1312,10 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), 'b = 5*1\n')
 
-    def test_compressed_repeating_float(self):
+    def test_repeat_repeating_float(self):
         nml_dict = {'a':{'b' : [1.0, 1.0, 2.0, 0.3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1323,10 +1323,10 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), 'b = 2*1.0, 2.0, 0.3\n')
 
-    def test_compressed_repeating_complex(self):
+    def test_repeat_repeating_complex(self):
         nml_dict = {'a':{'b' : [1+2j, 1+2j, 3j]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1334,10 +1334,10 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), 'b = 2*(1.0, 2.0), (0.0, 3.0)\n')
 
-    def test_compressed_repeating_logical(self):
+    def test_repeat_repeating_logical(self):
         nml_dict = {'a':{'b' : [True, True, False]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.compressed = True
+        nml.repeat = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -1218,6 +1218,11 @@ class Test(unittest.TestCase):
         nml.compressed = True
         self.assertTrue(nml.compressed)
 
+    def test_set_compressed_flag_incorrect(self):
+        nml = f90nml.Namelist()
+        with self.assertRaises(TypeError):
+            nml.compressed = 'Hello'
+
     # TODO fails in _var_strings 
     # def test_compressed_empty(self):
         # nml_dict = {'a':{'b' : []}}

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -1209,6 +1209,38 @@ class Test(unittest.TestCase):
 
         f90nml.cli.has_yaml = orig_has_yaml
 
+    def test_check_compressed_flag(self):
+        nml = f90nml.Namelist()
+        self.assertFalse(nml.compressed)
+
+    def test_set_compressed_flag(self):
+        nml = f90nml.Namelist()
+        nml.compressed = True
+        self.assertTrue(nml.compressed)
+
+    # TODO fails in _var_strings 
+    # def test_compressed_empty(self):
+        # nml_dict = {'a':{'b' : []}}
+        # nml = f90nml.Namelist(nml_dict)
+        # nml.compressed = True
+        # out = StringIO()
+        # print(nml, file=out)
+        # out.seek(0)
+        # line1 = out.readline()
+        # line2 = out.readline()
+        # self.assertEqual(line2.lstrip(), 'b = 1, 2, 3\n')
+
+    def test_compressed_single(self):
+        nml_dict = {'a':{'b' : [1]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 1\n')
+
     def test_compressed_no_consecutive(self):
         nml_dict = {'a':{'b' : [1, 2, 3]}}
         nml = f90nml.Namelist(nml_dict)

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -1210,17 +1210,17 @@ class Test(unittest.TestCase):
 
     def test_check_repeat_flag(self):
         nml = f90nml.Namelist()
-        self.assertFalse(nml.repeat)
+        self.assertFalse(nml.repeat_counter)
 
     def test_set_repeat_flag(self):
         nml = f90nml.Namelist()
-        nml.repeat = True
-        self.assertTrue(nml.repeat)
+        nml.repeat_counter = True
+        self.assertTrue(nml.repeat_counter)
 
     def test_set_repeat_flag_incorrect(self):
         nml = f90nml.Namelist()
         with self.assertRaises(TypeError):
-            nml.repeat = 'Hello'
+            nml.repeat_counter = 'Hello'
 
     # TODO fails in _var_strings 
     # def test_repeat_empty(self):
@@ -1237,7 +1237,7 @@ class Test(unittest.TestCase):
 
     def test_repeat_scalar(self):
         nml = f90nml.Namelist({'a':{'b':1}})
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1249,7 +1249,7 @@ class Test(unittest.TestCase):
     def test_repeat_single(self):
         nml_dict = {'a':{'b' : [1]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1260,7 +1260,7 @@ class Test(unittest.TestCase):
     def test_repeat_no_consecutive(self):
         nml_dict = {'a':{'b' : [1, 2, 3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1271,7 +1271,7 @@ class Test(unittest.TestCase):
     def test_repeat_middle_consecutive(self):
         nml_dict = {'a':{'b' : [1, 2, 2, 3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1282,7 +1282,7 @@ class Test(unittest.TestCase):
     def test_repeat_beginning_consecutive(self):
         nml_dict = {'a':{'b' : [1, 1, 2, 3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1293,7 +1293,7 @@ class Test(unittest.TestCase):
     def test_repeat_end_consecutive(self):
         nml_dict = {'a':{'b' : [1, 2, 3, 3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1304,7 +1304,7 @@ class Test(unittest.TestCase):
     def test_repeat_consecutive_repeating(self):
         nml_dict = {'a':{'b' : [1, 1, 2, 3, 1, 1, 1]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1315,7 +1315,7 @@ class Test(unittest.TestCase):
     def test_repeat_all_repeating(self):
         nml_dict = {'a':{'b' : [1, 1, 1, 1, 1]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1326,7 +1326,7 @@ class Test(unittest.TestCase):
     def test_repeat_repeating_float(self):
         nml_dict = {'a':{'b' : [1.0, 1.0, 2.0, 0.3]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1337,7 +1337,7 @@ class Test(unittest.TestCase):
     def test_repeat_repeating_complex(self):
         nml_dict = {'a':{'b' : [1+2j, 1+2j, 3j]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)
@@ -1348,7 +1348,7 @@ class Test(unittest.TestCase):
     def test_repeat_repeating_logical(self):
         nml_dict = {'a':{'b' : [True, True, False]}}
         nml = f90nml.Namelist(nml_dict)
-        nml.repeat = True
+        nml.repeat_counter = True
         out = StringIO()
         print(nml, file=out)
         out.seek(0)

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -35,7 +35,6 @@ from f90nml.fpy import pybool
 from f90nml.namelist import Namelist
 from f90nml.findex import FIndex
 
-
 class Test(unittest.TestCase):
 
     def setUp(self):
@@ -1234,6 +1233,18 @@ class Test(unittest.TestCase):
         # line1 = out.readline()
         # line2 = out.readline()
         # self.assertEqual(line2.lstrip(), 'b = 1, 2, 3\n')
+
+
+    def test_repeat_scalar(self):
+        nml = f90nml.Namelist({'a':{'b':1}})
+        nml.repeat = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 1\n')
+        
 
     def test_repeat_single(self):
         nml_dict = {'a':{'b' : [1]}}

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -1209,6 +1209,105 @@ class Test(unittest.TestCase):
 
         f90nml.cli.has_yaml = orig_has_yaml
 
+    def test_compressed_no_consecutive(self):
+        nml_dict = {'a':{'b' : [1, 2, 3]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 1, 2, 3\n')
+
+    def test_compressed_middle_consecutive(self):
+        nml_dict = {'a':{'b' : [1, 2, 2, 3]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 1, 2*2, 3\n')
+
+    def test_compressed_beginning_consecutive(self):
+        nml_dict = {'a':{'b' : [1, 1, 2, 3]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 2*1, 2, 3\n')
+
+    def test_compressed_end_consecutive(self):
+        nml_dict = {'a':{'b' : [1, 2, 3, 3]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 1, 2, 2*3\n')
+
+    def test_compressed_consecutive_repeating(self):
+        nml_dict = {'a':{'b' : [1, 1, 2, 3, 1, 1, 1]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 2*1, 2, 3, 3*1\n')
+
+    def test_compressed_all_repeating(self):
+        nml_dict = {'a':{'b' : [1, 1, 1, 1, 1]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 5*1\n')
+
+    def test_compressed_repeating_float(self):
+        nml_dict = {'a':{'b' : [1.0, 1.0, 2.0, 0.3]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 2*1.0, 2.0, 0.3\n')
+
+    def test_compressed_repeating_complex(self):
+        nml_dict = {'a':{'b' : [1+2j, 1+2j, 3j]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), 'b = 2*(1.0, 2.0), (0.0, 3.0)\n')
+
+    def test_compressed_repeating_logical(self):
+        nml_dict = {'a':{'b' : [True, True, False]}}
+        nml = f90nml.Namelist(nml_dict)
+        nml.compressed = True
+        out = StringIO()
+        print(nml, file=out)
+        out.seek(0)
+        line1 = out.readline()
+        line2 = out.readline()
+        self.assertEqual(line2.lstrip(), "b = 2*.true., .false.\n")
+
     # Failed namelist parsing
     # NOTE: This is a very weak test, since '& x=1' / will pass
     def test_grp_token_end(self):


### PR DESCRIPTION
Allows output in compressed form, resolves issue #122 

New namelist property: `compressed`. Defaults to False, if True, arrays are compressed on output.

Changes method _var_strings by two methods:

`_compress` converts the `v_values` list to a compressed list where each element is a 2-element list with the number of repetitions and the original element.

`_f90comprepr` converts each of these individual 2-element lists into the correct compressed format.

Several tests were added for this feature.