### PR TITLE
Squeeze 1d lists due to repeated variables

### DIFF
--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -396,6 +396,15 @@ class Parser(object):
 
                     g_vars[v_name] = v_values
 
+                    # Squeeze 1d list due to repeated variables
+                    for v_name, v_values in g_vars.items():
+                        if (
+                            isinstance(v_values, list)
+                            and len(v_values) == 1
+                            and v_name not in g_vars.start_index
+                        ):
+                            g_vars[v_name] = v_values[0]
+
                     # Deselect variable
                     v_name = None
                     v_values = []


### PR DESCRIPTION
Hi!
This PR should fix #82.

Looks like it's fixing the bug without breaking any test. But I'm not familiar with the code so it's likely there are better solutions or I'm overlooking something.

I'd be happy to revise it and/or make additions (e.g., add a test, add a warning when variables are repeated, ...).


Example:
```python
import f90nml
f90nml.reads(
"""
&test
    a = 1
    a = 2
    a = 3
/
"""
)
```
now returns:
```
Namelist([('test', Namelist([('a', 3)]))])
```