### PR TITLE
Change to accept NumPy 0D arrays in _f90repr

### DIFF
--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -32,6 +32,12 @@ except ImportError:
     from collections import KeysView        # Python 2.7 - 3.3
     from collections import ItemsView       # Python 2.7 - 3.3
 
+try:
+    import numpy as np
+    has_numpy = True
+except ImportError:
+    has_numpy = False
+
 
 class _NamelistKeysView(KeysView):
     """Return the namelist's KeysView based on the Namelist iterator."""
@@ -966,6 +972,16 @@ class Namelist(OrderedDict):
             return self._f90str(value)
         elif value is None:
             return ''
+        elif has_numpy and isinstance(value, np.ndarray) and np.ndim(value) == 0:
+            # If receiving a 0D Numpy array, convert to underlying type
+            # Special case to handle numpy.bool_ and string types
+            if value.dtype == bool:
+                value = bool(value[()])
+            elif value.dtype == str:
+                value = str(value[()])
+            else:
+                value = value[()]
+            return self._f90repr(value)
         else:
             raise ValueError('Type {0} of {1} cannot be converted to a Fortran'
                              ' type.'.format(type(value), value))

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -971,6 +971,21 @@ class Test(unittest.TestCase):
         for ptype in ({}, [], set()):
             self.assertRaises(ValueError, nml._f90repr, ptype)
 
+    def test_f90repr_numpy_0d(self):
+        # If we don't have numpy installed, skip this test
+        if not has_numpy:
+            return
+        nml = f90nml.Namelist()
+        self.assertEqual(nml._f90repr(numpy.array(1)), '1')
+        self.assertEqual(nml._f90repr(numpy.array(1.)), '1.0')
+        self.assertEqual(nml._f90repr(numpy.array(1+2j)), '(1.0, 2.0)')
+        self.assertEqual(nml._f90repr(numpy.array(True)), '.true.')
+        self.assertEqual(nml._f90repr(numpy.array(False)), '.false.')
+        self.assertEqual(nml._f90repr(numpy.array('abc')), "'abc'")
+        # Test ValueError raised for non-scalar arrays, even with shape (1,)
+        self.assertRaises(ValueError, nml._f90repr, numpy.array([1, 2, 3]))
+        self.assertRaises(ValueError, nml._f90repr, numpy.array([1]))
+
     def test_pybool(self):
         for fstr_true in ('true', '.true.', 't', '.t.'):
             self.assertEqual(pybool(fstr_true), True)


### PR DESCRIPTION
Hi there! We've been using f90nml in [Pyrokinetics](https://github.com/pyro-kinetics/pyrokinetics) to read/write input files to plasma physics codes, and we ran into an issue where NumPy 0D arrays would propagate unnoticed into a `Namelist` and cause an exception to be thrown on calling `Namelist.write`. I've added a small change to `Namelist._f90repr` to detect 0D arrays and convert them to their equivalent primitive type. Nothing changes if NumPy is not installed.

Let me know if you'd like me to add further test cases, or if you'd prefer to avoid including these sorts of edge cases in your library.