### PR TITLE
Update README with conda-forge install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ The latest version of ``f90nml`` can be installed from source::
 conda
 -----
 
-There is a conda-forge feedstock (not maintained, no supported by, the Author). 
+There is a conda-forge feedstock (not maintained, nor supported by, the Author). 
 
 Information on supported versions and platforms, and detailed installation instructions
 using ``conda`` and ``conda-forge`` is available here:

--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,20 @@ The latest version of ``f90nml`` can be installed from source::
    $ cd f90nml
    $ pip install .
 
+conda
+-----
+
+There is a conda-forge feedstock (not maintained, no supported by, the Author). 
+
+Information on supported versions and platforms, and detailed installation instructions
+using ``conda`` and ``conda-forge`` is available here:
+
+   https://github.com/conda-forge/f90nml-feedstock
+
+but TL;DR::
+
+    $ conda install -c conda-forge f90nml
+
 
 Package distribution
 --------------------


### PR DESCRIPTION
Update README with details of the [conda-forge feedstock](https://github.com/conda-forge/f90nml-feedstock) available, and a pointer to some detailed installation instructions

Closes #164 

If you wanted you could add the conda-forge shields too

https://github.com/conda-forge/f90nml-feedstock/blob/main/README.md?plain=1#L30

but I can see the argument for leaving that to the feedstock page