### PR TITLE
Formatting option assign_spacing

### DIFF
--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -127,6 +127,7 @@ class Namelist(OrderedDict):
         self._float_format = ''
         self._logical_repr = {False: '.false.', True: '.true.'}
         self._index_spacing = False
+        self._assign_spacing = True
         self._repeat_counter = False
         self._split_strings = False
 
@@ -423,6 +424,22 @@ class Namelist(OrderedDict):
         if not isinstance(value, bool):
             raise TypeError('index_spacing attribute must be a logical type.')
         self._index_spacing = value
+
+    @property
+    def assign_spacing(self):
+        """Apply a space before and after the `=` in an assignment.
+
+        :type: ``bool``
+        :default: ``True``
+        """
+        return self._assign_spacing
+
+    @assign_spacing.setter
+    def assign_spacing(self, value):
+        """Validate and set the assign_spacing flag."""
+        if not isinstance(value, bool):
+            raise TypeError('assign_spacing attribute must be a logical type.')
+        self._assign_spacing = value
 
     # NOTE: This presumes that bools and ints are identical as dict keys
     @property
@@ -823,7 +840,11 @@ class Namelist(OrderedDict):
                 v_idx_repr = ''
 
             # Split output across multiple lines (if necessary)
-            v_header = self.indent + v_name + v_idx_repr + ' = '
+            v_header = self.indent + v_name + v_idx_repr
+            if self._assign_spacing:
+                v_header += ' = '
+            else:
+                v_header += '='
             val_strs = []
             val_line = v_header
 

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -1100,6 +1100,13 @@ class Test(unittest.TestCase):
 
         self.assertRaises(TypeError, setattr, test_nml, 'index_spacing', 123)
 
+    def test_assign_spacing(self):
+        test_nml = f90nml.read('types.nml')
+        test_nml.assign_spacing = False
+        self.assert_write(test_nml, 'types_assign_spacing.nml')
+
+        self.assertRaises(TypeError, setattr, test_nml, 'assign_spacing', 'xyz')
+
     def test_float_format(self):
         test_nml = f90nml.read('float.nml')
         test_nml.float_format = '.3f'

--- a/tests/types_assign_spacing.nml
+++ b/tests/types_assign_spacing.nml
@@ -1,0 +1,7 @@
+&types_nml
+    v_integer=1
+    v_float=1.0
+    v_complex=(1.0, 2.0)
+    v_logical=.true.
+    v_string='Hello'
+/


### PR DESCRIPTION
This introduces a new property `Namelist.assign_spacing `that allows to trigger the use of white spacing around the assignment operator in the output. Default value is `True`, retaining current behaviour. An Associated test is included.

This will incur the following change in the output.
Default (`Namelist.assign_spacing = True`):
```
&types_nml
    v_integer = 1
    v_float = 1.0
    v_complex = (1.0, 2.0)
    v_logical = .true.
    v_string = 'Hello'
/
```
With `Namelist.assign_spacing = False`:
```
&types_nml
    v_integer=1
    v_float=1.0
    v_complex=(1.0, 2.0)
    v_logical=.true.
    v_string='Hello'
/
```

The rationale for this is that our default namelist format is without white space around the assignment operator, and some scripts implicitly rely on this. Until we have resolved this, the conservative formatting reduces the diff and retains compatibility.