### PR TITLE
Fix: raise error when namelist group is not closed before the start of a new group

### DIFF
--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -329,6 +329,9 @@ class Parser(object):
             except StopIteration:
                 break
 
+            # save whether & or $ is opening this group
+            opening_token = self.token
+
             # Create the next namelist
             try:
                 self._update_tokens()
@@ -384,20 +387,22 @@ class Parser(object):
                 # Finalise namelist group
                 if self.token in ('/', '&', '$'):
 
-                    if self.token == '&':
+                    if self.token in ('&', '$'):
                         # Peek at the next non-whitespace token without
                         # consuming it, to distinguish F77-style terminators
-                        # (&end or standalone &) from an unclosed group.
+                        # (&end or standalone &, or same with $) from
+                        # an unclosed group.
                         self.tokens, peek_iter = itertools.tee(self.tokens)
                         skip = self.comment_tokens + whitespace
                         next_tok = next(
-                            (t for t in peek_iter if t[0] not in skip), None
+                            (t for t in peek_iter if t[0] not in skip),
+                            None
                         )
-                        if next_tok not in ('end', '&', '$', None):
+                        if next_tok and next_tok.lower() not in ('end', '&', '$'):
                             raise ValueError(
-                                "f90nml: error: Namelist group '&{}' was not "
-                                "closed before the start of a new group."
-                                .format(g_name)
+                                "f90nml: error: Namelist group '{}{}' was not "
+                                "closed before the start of a new group or EOF."
+                                .format(opening_token, g_name)
                             )
 
                     # Append any remaining patched variables

--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -384,6 +384,22 @@ class Parser(object):
                 # Finalise namelist group
                 if self.token in ('/', '&', '$'):
 
+                    if self.token == '&':
+                        # Peek at the next non-whitespace token without
+                        # consuming it, to distinguish F77-style terminators
+                        # (&end or standalone &) from an unclosed group.
+                        self.tokens, peek_iter = itertools.tee(self.tokens)
+                        skip = self.comment_tokens + whitespace
+                        next_tok = next(
+                            (t for t in peek_iter if t[0] not in skip), None
+                        )
+                        if next_tok not in ('end', '&', '$', None):
+                            raise ValueError(
+                                "f90nml: error: Namelist group '&{}' was not "
+                                "closed before the start of a new group."
+                                .format(g_name)
+                            )
+
                     # Append any remaining patched variables
                     for v_name, v_val in grp_patch.items():
                         g_vars[v_name] = v_val

--- a/tests/end_uppercase.nml
+++ b/tests/end_uppercase.nml
@@ -1,0 +1,7 @@
+&END_TOKEN_UPPERCASE
+  a = 1
+&END
+
+&last_grp
+  a = 1
+&

--- a/tests/f77.nml
+++ b/tests/f77.nml
@@ -1,3 +1,7 @@
+$f77_nml_dollar
+    x = 123
+$end
+
 &f77_nml
     x = 123
 &end
@@ -5,3 +9,7 @@
 &next_f77_nml
     y = 'abc'
 &end
+
+&another_f77_nml
+    z = 99
+&

--- a/tests/f77_target.nml
+++ b/tests/f77_target.nml
@@ -1,7 +1,15 @@
+&f77_nml_dollar
+    x = 123
+/
+
 &f77_nml
     x = 123
 /
 
 &next_f77_nml
     y = 'abc'
+/
+
+&another_f77_nml
+    z = 99
 /

--- a/tests/first_grp_no_end.nml
+++ b/tests/first_grp_no_end.nml
@@ -1,0 +1,6 @@
+&open_group
+a = 1
+
+&closed_group
+b = 2
+/

--- a/tests/first_grp_no_end_dollar.nml
+++ b/tests/first_grp_no_end_dollar.nml
@@ -1,0 +1,7 @@
+$open_group
+a = 1
+
+
+$closed_group
+b = 2
+$end

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -1597,6 +1597,11 @@ class Test(unittest.TestCase):
         line2 = out.readline()
         self.assertEqual(line2.lstrip(), "b = 2*.true., .false.\n")
 
+    def test_end_uppercase(self):
+        test_nml = f90nml.read('end_uppercase.nml')
+        self.assertEqual(test_nml, {'end_token_uppercase': {'a': 1},
+                                    'last_grp': {'a': 1}})
+
     # Failed namelist parsing
     # NOTE: This is a very weak test, since '& x=1' / will pass
     def test_grp_token_end(self):
@@ -1616,6 +1621,9 @@ class Test(unittest.TestCase):
 
     def test_file_first_grp_no_end(self):
         self.assertRaises(ValueError, f90nml.read, 'first_grp_no_end.nml')
+
+    def test_file_first_grp_no_end_dollar(self):
+        self.assertRaises(ValueError, f90nml.read, 'first_grp_no_end_dollar.nml')
 
 
 if __name__ == '__main__':

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -427,8 +427,10 @@ class Test(unittest.TestCase):
         }
 
         self.f77_nml = {
+            'f77_nml_dollar': {'x': 123},
             'f77_nml': {'x': 123},
             'next_f77_nml': {'y': 'abc'},
+            'another_f77_nml': {'z': 99},
         }
 
         self.dollar_nml = {'dollar_nml': {'v': 1.}}

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -1612,6 +1612,9 @@ class Test(unittest.TestCase):
     def test_file_grp_no_end(self):
         self.assertRaises(ValueError, f90nml.read, 'grp_no_end.nml')
 
+    def test_file_first_grp_no_end(self):
+        self.assertRaises(ValueError, f90nml.read, 'first_grp_no_end.nml')
+
 
 if __name__ == '__main__':
     if os.path.isfile('tmp.nml'):


### PR DESCRIPTION
Hi, I hope this is okay to submit — I ran into a bug where a missing / terminator on a namelist group would silently cause the following group to be skipped entirely. For example, in a file like:

```
  &open_group
  a = 1

  &closed_group
  b = 2
  /
```

closed_group would be silently dropped from the parsed result, which can be pretty hard to debug. I've looked at the bevahiour of gfortran and ifx for this case. gfortran errors and exits. ifx reads both groups without warning. I prefer an error personally so I made the fix to be an error.

The fix peeks at the next non-whitespace token when & is seen as a group terminator. If it's not a recognised F77-style terminator (&end, standalone &, or $), a ValueError is raised pointing to the offending group. itertools.tee is used to peek without consuming from the token stream, which felt consistent with how lookahead is already handled elsewhere in the parser.

This might also relate to this issue: #160 

Would be happy to adjust anything if this doesn't fit. Thanks for considering it!