### PR TITLE
Fix indexed array assignment + indexed derived types and a bit more

### DIFF
--- a/f90nml/findex.py
+++ b/f90nml/findex.py
@@ -22,6 +22,16 @@ class FIndex(object):
         else:
             self.first = [b[0] for b in bounds]
 
+    def __str__(self):
+        return "{0}(start={1}, end={2}, step={3}, current={4}, first={5})".format(
+            type(self).__name__,
+            self.start,
+            self.end,
+            self.step,
+            self.current,
+            self.first,
+        )
+
     def __iter__(self):
         """Declare object as iterator."""
         return self

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -820,34 +820,14 @@ class Namelist(OrderedDict):
             for f_name, f_vals in v_values.items():
                 v_start_new = v_values.start_index.get(f_name, None)
 
-                # Handle derived type parent array indexing
-                if (f_name.lower() in v_values.parent_indexed
-                        and isinstance(f_vals, list)):
+                # Handle derived type parent array indexing.  The bound
+                # `(s:e)` belongs to `v_name`; emit `v_name(idx)%f_name%...`
+                # lines.  Walks into `f_vals` if it is itself a Namelist
+                # (e.g. `arr(1:2)%inner%foo = ...`).
+                if f_name.lower() in v_values.parent_indexed:
                     i_s = v_start_new[0] if v_start_new else 1
-
-                    # If there are any indices skipped, we have to go 1-by-1
-                    if any(v is None for v in f_vals):
-                        for offset, val in enumerate(f_vals):
-                            if val is not None:
-                                # parent_name(idx)%f_name
-                                sub = '{0}({1})%{2}'.format(
-                                    v_name, i_s + offset, f_name)
-                                v_strs = self._var_strings(sub, val)
-                                var_strs.extend(v_strs)
-                    else:
-                        i_e = i_s + len(f_vals) - 1
-                        if i_s == i_e:
-                            # single array element (start/end same)
-                            # parent_name(idx)%f_name
-                            sub = '{0}({1})%{2}'.format(
-                                v_name, i_s, f_name)
-                        else:
-                            # parent_name(start_idx:end_idx)%f_name
-                            sub = '{0}({1}:{2})%{3}'.format(
-                                v_name, i_s, i_e, f_name)
-                        v_strs = self._var_strings(sub, f_vals,
-                                                   exclude_index=True)
-                        var_strs.extend(v_strs)
+                    var_strs.extend(self._make_parent_indexed_lines(
+                        v_name, f_name, f_vals, i_s))
                     continue
 
                 v_title = '%'.join([v_name, f_name])
@@ -1004,6 +984,52 @@ class Namelist(OrderedDict):
                 var_strs.extend(val_strs)
 
         return var_strs
+
+    def _make_parent_indexed_lines(self, parent_name, path, value, i_s):
+        """Make `parent_name(s:e)%path%... = ...` lines."""
+        if isinstance(value, Namelist):
+            # Nested derived type
+            lines = []
+            for f_name, f_vals in value.items():
+                path_and_name = "{0}%{1}".format(path, f_name)
+                lines.extend(
+                    self._make_parent_indexed_lines(
+                        parent_name, path_and_name, f_vals, i_s
+                    )
+                )
+            return lines
+
+        # Non-list scalar leaf: a single `(idx)` slot.
+        # parent_name(idx)%path
+        if not isinstance(value, list):
+            title = "{0}({1}){2}".format(parent_name, i_s, "%" + path if path else "")
+            return self._var_strings(title, value)
+
+        # If there are any indices skipped, we have to go 1-by-1
+        if any(v is None for v in value):
+            lines = []
+            for offset, val in enumerate(value):
+                if val is None:
+                    continue
+                # parent_name(idx)%path
+                title = "{0}({1}){2}".format(
+                    parent_name, i_s + offset, "%" + path if path else ""
+                )
+                lines.extend(self._var_strings(title, val))
+            return lines
+
+        # Dense list leaf: a single `(s:e)` slice.
+        i_e = i_s + len(value) - 1
+        if i_s == i_e:
+            # Single array element (start/end same)
+            # parent_name(idx)%path
+            title = "{0}({1}){2}".format(parent_name, i_s, "%" + path if path else "")
+        else:
+            # parent_name(start_idx:end_idx)%path
+            title = "{0}({1}:{2}){3}".format(
+                parent_name, i_s, i_e, "%" + path if path else ""
+            )
+        return self._var_strings(title, value, exclude_index=True)
 
     def todict(self, complex_tuple=False):
         """Return a dict equivalent to the namelist.

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -112,16 +112,6 @@ class Namelist(OrderedDict):
         # in the namelist
         self._positional = set(self.pop('_positional', ()))
 
-        # _parent_indexed: set of lowercase names that come from a parent-indexed
-        # derived-type assignment
-        #
-        # Compare `ele_name` in these two cases:
-        #  1. `var(1:6)%ele_name = ...`.
-        #  2. `var%ele_name(1:6) = ...`.
-        #
-        #  (1) is parent-indexed, whereas (2) is not.
-        self._parent_indexed = set(self.pop('_parent_indexed', ()))
-
         # NOTE: The `_positional_row` metadata key is intentionally left
         # in the dict. I don't see a way around storing this separately,
         # as otherwise the user won't have access to the data when
@@ -584,16 +574,6 @@ class Namelist(OrderedDict):
         return self._positional
 
     @property
-    def parent_indexed(self):
-        """
-        Child names that should round-trip as ``parent(s:e)%child``.
-
-        :type: ``set[str]``
-        :default: ``set()``
-        """
-        return self._parent_indexed
-
-    @property
     def sliced_attrs(self):
         """Map of variable name to fields that came from a slice.
 
@@ -854,16 +834,6 @@ class Namelist(OrderedDict):
 
                 v_start_new = v_values.start_index.get(f_name, None)
 
-                # Handle derived type parent array indexing.  The bound
-                # `(s:e)` belongs to `v_name`; emit `v_name(idx)%f_name%...`
-                # lines.  Walks into `f_vals` if it is itself a Namelist
-                # (e.g. `arr(1:2)%inner%foo = ...`).
-                if f_name.lower() in v_values.parent_indexed:
-                    i_s = v_start_new[0] if v_start_new else 1
-                    var_strs.extend(self._make_parent_indexed_lines(
-                        v_name, f_name, f_vals, i_s))
-                    continue
-
                 v_title = _join_attr(v_name, f_name)
 
                 v_strs = self._var_strings(v_title, f_vals,
@@ -896,7 +866,7 @@ class Namelist(OrderedDict):
                          else None)
                         for val in v_values
                     ]
-                    var_strs.extend(self._make_parent_indexed_lines(
+                    var_strs.extend(self._make_sliced_attr_lines(
                         v_name, attr, attr_vals, i_s))
 
         else:
@@ -1030,21 +1000,8 @@ class Namelist(OrderedDict):
 
         return var_strs
 
-    def _make_parent_indexed_lines(self, parent_name, path, value, i_s):
-        """Make `parent_name(s:e)%path%... = ...` lines."""
-        if isinstance(value, Namelist):
-            # Nested derived type
-            lines = []
-            for f_name, f_vals in value.items():
-                lines.extend(
-                    self._make_parent_indexed_lines(
-                        parent_name,
-                        _join_attr(path, f_name),
-                        f_vals, i_s
-                    )
-                )
-            return lines
-
+    def _make_sliced_attr_lines(self, parent_name, path, value, i_s):
+        """Emit compact `parent_name(s:e)%path = ...` lines for a slice."""
         # Try to use a stride first (`(start:end:stride)`) if possible;
         # otherwise fall back to one line per non-None entry.
         if any(v is None for v in value):
@@ -1123,13 +1080,12 @@ class Namelist(OrderedDict):
                     except KeyError:
                         nmldict['_complex'] = [key]
 
-        # Append the start index, positional and parent-indexed flags if present
+        # Append the start index, positional and sliced-attribute flags if
+        # present
         if self.start_index:
             nmldict['_start_index'] = self.start_index
         if self.positional:
             nmldict['_positional'] = sorted(self.positional)
-        if self.parent_indexed:
-            nmldict['_parent_indexed'] = sorted(self.parent_indexed)
         if self.sliced_attrs:
             nmldict['_sliced_attrs'] = {
                 k: sorted(v) for k, v in self.sliced_attrs.items()

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -787,10 +787,6 @@ class Namelist(OrderedDict):
                 if val is None:
                     continue
                 title = _join_attr(v_name, index=idx)
-                # Handle the full positional row first
-                if isinstance(val, Namelist) and '_positional_row' in val:
-                    var_strs.extend(self._var_strings(
-                        title, val['_positional_row']))
                 var_strs.extend(self._var_strings(title, val))
             return var_strs
 
@@ -824,6 +820,12 @@ class Namelist(OrderedDict):
 
         # Parse derived type contents
         elif isinstance(v_values, Namelist):
+            # Positional row comes first, as the others might override it (and
+            # we can't tell)
+            if '_positional_row' in v_values:
+                var_strs.extend(self._var_strings(
+                    v_name, v_values['_positional_row']))
+
             for f_name, f_vals in v_values.items():
                 # `_positional_row` is actual data, but handled elsewhere
                 if f_name == '_positional_row':

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -1045,12 +1045,6 @@ class Namelist(OrderedDict):
                 )
             return lines
 
-        # Non-list scalar leaf: a single `(idx)` slot.
-        # parent_name(idx)%path
-        if not isinstance(value, list):
-            title = _join_attr(parent_name, path, index=i_s)
-            return self._var_strings(title, value)
-
         # Try to use a stride first (`(start:end:stride)`) if possible;
         # otherwise fall back to one line per non-None entry.
         if any(v is None for v in value):

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -1019,8 +1019,19 @@ class Namelist(OrderedDict):
             title = _join_attr(parent_name, path, index=i_s)
             return self._var_strings(title, value)
 
-        # If there are any indices skipped, we have to go 1-by-1
+        # Try to use a stride first (`(start:end:stride)`) if possible;
+        # otherwise fall back to one line per non-None entry.
         if any(v is None for v in value):
+            non_none = [(i, v) for i, v in enumerate(value) if v is not None]
+            stride = _get_array_stride([i for i, _ in non_none])
+            if stride is not None:
+                start = i_s + non_none[0][0]
+                end = i_s + non_none[-1][0]
+                title = _join_attr(
+                    parent_name, path, index=(start, end, stride))
+                return self._var_strings(
+                    title, [v for _, v in non_none], exclude_index=True)
+
             lines = []
             for offset, val in enumerate(value):
                 if val is None:
@@ -1231,6 +1242,19 @@ class NmlKey(str):
         return tok
 
 
+def _get_array_stride(offsets):
+    """Find a usable stride of `offsets`, if possible."""
+    if len(offsets) < 2:
+        return None
+    stride = offsets[1] - offsets[0]
+    if stride <= 1:
+        return None
+    for k in range(len(offsets) - 1):
+        if offsets[k + 1] - offsets[k] != stride:
+            return None
+    return stride
+
+
 def _cogroup_basename(grp):
     """Return the cogroup name from the internal key."""
     return grp[5:].rsplit('_', 1)[0] if grp.startswith('_grp_') else grp
@@ -1242,9 +1266,8 @@ def _join_attr(*parts, **kwargs):
     If kwarg `index` is provided, it represents an index on the first part.
     The formatting depends on the type of `index`:
     int: ``(idx)``
-    2-tuple: ``(start:end)``
-    With a special case of ``(start)`` when the start and end indices are the
-    same.
+    2-tuple: ``(start:end)``, collapsed to ``(start)`` when start == end
+    3-tuple: ``(start:end:stride)``
     """
     # TODO: move this to a kwarg once f90nml is Python 3+...
     index = kwargs.pop('index', None)
@@ -1255,6 +1278,9 @@ def _join_attr(*parts, **kwargs):
     if index is not None:
         if isinstance(index, int):
             suffix = '({0})'.format(index)
+        elif len(index) == 3:
+            start, end, stride = index
+            suffix = '({0}:{1}:{2})'.format(start, end, stride)
         else:
             start, end = index
             if start == end:

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -830,7 +830,7 @@ class Namelist(OrderedDict):
                         v_name, f_name, f_vals, i_s))
                     continue
 
-                v_title = '%'.join([v_name, f_name])
+                v_title = _join_attr(v_name, f_name)
 
                 v_strs = self._var_strings(v_title, f_vals,
                                            v_start=v_start_new)
@@ -991,10 +991,11 @@ class Namelist(OrderedDict):
             # Nested derived type
             lines = []
             for f_name, f_vals in value.items():
-                path_and_name = "{0}%{1}".format(path, f_name)
                 lines.extend(
                     self._make_parent_indexed_lines(
-                        parent_name, path_and_name, f_vals, i_s
+                        parent_name,
+                        _join_attr(path, f_name),
+                        f_vals, i_s
                     )
                 )
             return lines
@@ -1002,7 +1003,7 @@ class Namelist(OrderedDict):
         # Non-list scalar leaf: a single `(idx)` slot.
         # parent_name(idx)%path
         if not isinstance(value, list):
-            title = "{0}({1}){2}".format(parent_name, i_s, "%" + path if path else "")
+            title = _join_attr(parent_name, path, index=i_s)
             return self._var_strings(title, value)
 
         # If there are any indices skipped, we have to go 1-by-1
@@ -1012,23 +1013,13 @@ class Namelist(OrderedDict):
                 if val is None:
                     continue
                 # parent_name(idx)%path
-                title = "{0}({1}){2}".format(
-                    parent_name, i_s + offset, "%" + path if path else ""
-                )
+                title = _join_attr(parent_name, path, index=i_s + offset)
                 lines.extend(self._var_strings(title, val))
             return lines
 
-        # Dense list leaf: a single `(s:e)` slice.
+        # Dense list leaf: a single `(start:end)%path` slice
         i_e = i_s + len(value) - 1
-        if i_s == i_e:
-            # Single array element (start/end same)
-            # parent_name(idx)%path
-            title = "{0}({1}){2}".format(parent_name, i_s, "%" + path if path else "")
-        else:
-            # parent_name(start_idx:end_idx)%path
-            title = "{0}({1}:{2}){3}".format(
-                parent_name, i_s, i_e, "%" + path if path else ""
-            )
+        title = _join_attr(parent_name, path, index=(i_s, i_e))
         return self._var_strings(title, value, exclude_index=True)
 
     def todict(self, complex_tuple=False):
@@ -1230,6 +1221,36 @@ class NmlKey(str):
 def _cogroup_basename(grp):
     """Return the cogroup name from the internal key."""
     return grp[5:].rsplit('_', 1)[0] if grp.startswith('_grp_') else grp
+
+
+def _join_attr(*parts, **kwargs):
+    """Join non-empty path parts with the Fortran `%` attribute separator.
+
+    If kwarg `index` is provided, it represents an index on the first part.
+    The formatting depends on the type of `index`:
+    int: ``(idx)``
+    2-tuple: ``(start:end)``
+    With a special case of ``(start)`` when the start and end indices are the
+    same.
+    """
+    # TODO: move this to a kwarg once f90nml is Python 3+...
+    index = kwargs.pop('index', None)
+    if kwargs:
+        raise TypeError(
+            'unexpected keyword argument(s): {0}'.format(sorted(kwargs)))
+
+    if index is not None:
+        if isinstance(index, int):
+            suffix = '({0})'.format(index)
+        else:
+            start, end = index
+            if start == end:
+                suffix = '({0})'.format(start)
+            else:
+                suffix = '({0}:{1})'.format(start, end)
+        parts = (parts[0] + suffix,) + parts[1:]
+
+    return '%'.join(p for p in parts if p)
 
 
 def is_nullable_list(val, vtype):

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -128,9 +128,9 @@ class Namelist(OrderedDict):
         # the namelist mixes positional assignment of derived types
         # along with separate field references (ugh!)
 
-        # _sliced_attrs: {var_name: {field, ...}} — names whose
-        # `var(s:e)%field = v1, ..., vN` slice form was scattered into a
-        # list of derived-type elements at parse time.
+        # _sliced_attrs: {var_name: {field, ...}}
+        # map of variable name to set of fields which started out as slices
+        # during parse time.
         self._sliced_attrs = {
             k: set(v) for k, v in self.pop('_sliced_attrs', {}).items()
         }

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -233,12 +233,9 @@ class Namelist(OrderedDict):
             )
 
         # Convert list of dicts to list of namelists
-        elif is_nullable_list(value, dict):
+        elif isinstance(value, list):
             for i, v in enumerate(value):
-                if isinstance(v, Namelist) or v is None:
-                    value[i] = v
-                else:
-                    # value is a non-Namelist dict
+                if isinstance(v, dict) and not isinstance(v, Namelist):
                     value[i] = Namelist(
                         v,
                         default_start_index=self.default_start_index
@@ -778,13 +775,12 @@ class Namelist(OrderedDict):
 
         # Positional derived-type form: one `var(idx) = v1` line per inner row.
         # Each row is a flat list of mixed-type values.
-        if positional and is_nullable_list(v_values, list):
+        if positional and isinstance(v_values, list):
             i_s = v_start[0] if v_start else 1
             for idx, val in enumerate(v_values, start=i_s):
                 if val is not None:
-                    var_strs.extend(
-                        self._var_strings("{0}({1})".format(v_name, idx), val)
-                    )
+                    var_strs.extend(self._var_strings(
+                        _join_attr(v_name, index=idx), val))
             return var_strs
 
         # Parse a multidimensional array

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -128,6 +128,13 @@ class Namelist(OrderedDict):
         # the namelist mixes positional assignment of derived types
         # along with separate field references (ugh!)
 
+        # _sliced_attrs: {var_name: {field, ...}} — names whose
+        # `var(s:e)%field = v1, ..., vN` slice form was scattered into a
+        # list of derived-type elements at parse time.
+        self._sliced_attrs = {
+            k: set(v) for k, v in self.pop('_sliced_attrs', {}).items()
+        }
+
         # Update the complex tuples as intrinsics
         # TODO: We are effectively setting these twice.  Instead, fetch these
         # from s_args rather than relying on Namelist to handle the content.
@@ -587,6 +594,15 @@ class Namelist(OrderedDict):
         return self._parent_indexed
 
     @property
+    def sliced_attrs(self):
+        """Map of variable name to fields that came from a slice.
+
+        :type: ``dict[str, set[str]]``
+        :default: ``{}``
+        """
+        return self._sliced_attrs
+
+    @property
     def true_repr(self):
         """Set the string representation of logical true values.
 
@@ -764,15 +780,18 @@ class Namelist(OrderedDict):
 
             v_start = grp_vars.start_index.get(v_name, None)
             positional = v_name.lower() in grp_vars.positional
+            sliced_attrs = grp_vars.sliced_attrs.get(v_name.lower(), set())
 
             for v_str in self._var_strings(v_name, v_val, v_start=v_start,
-                                           positional=positional):
+                                           positional=positional,
+                                           sliced_attrs=sliced_attrs):
                 print(v_str, file=nml_file)
 
         print('/', file=nml_file)
 
     def _var_strings(self, v_name, v_values, v_idx=None, v_start=None,
-                     positional=False, exclude_index=False):
+                     positional=False, exclude_index=False,
+                     sliced_attrs=None, skip_fields=None):
         """Convert namelist variable to list of fixed-width strings."""
         if self.uppercase:
             v_name = v_name.upper()
@@ -830,6 +849,8 @@ class Namelist(OrderedDict):
                 # `_positional_row` is actual data, but handled elsewhere
                 if f_name == '_positional_row':
                     continue
+                if skip_fields and f_name.lower() in skip_fields:
+                    continue
 
                 v_start_new = v_values.start_index.get(f_name, None)
 
@@ -864,8 +885,19 @@ class Namelist(OrderedDict):
 
                 v_title = v_name + '({0})'.format(idx)
 
-                v_strs = self._var_strings(v_title, val)
+                v_strs = self._var_strings(
+                    v_title, val, skip_fields=sliced_attrs)
                 var_strs.extend(v_strs)
+
+            if sliced_attrs:
+                for attr in sorted(sliced_attrs):
+                    attr_vals = [
+                        (val[attr] if val is not None and attr in val
+                         else None)
+                        for val in v_values
+                    ]
+                    var_strs.extend(self._make_parent_indexed_lines(
+                        v_name, attr, attr_vals, i_s))
 
         else:
             use_default_start_index = False
@@ -1104,6 +1136,10 @@ class Namelist(OrderedDict):
             nmldict['_positional'] = sorted(self.positional)
         if self.parent_indexed:
             nmldict['_parent_indexed'] = sorted(self.parent_indexed)
+        if self.sliced_attrs:
+            nmldict['_sliced_attrs'] = {
+                k: sorted(v) for k, v in self.sliced_attrs.items()
+            }
 
         return nmldict
 

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -122,6 +122,12 @@ class Namelist(OrderedDict):
         #  (1) is parent-indexed, whereas (2) is not.
         self._parent_indexed = set(self.pop('_parent_indexed', ()))
 
+        # NOTE: The `_positional_row` metadata key is intentionally left
+        # in the dict. I don't see a way around storing this separately,
+        # as otherwise the user won't have access to the data when
+        # the namelist mixes positional assignment of derived types
+        # along with separate field references (ugh!)
+
         # Update the complex tuples as intrinsics
         # TODO: We are effectively setting these twice.  Instead, fetch these
         # from s_args rather than relying on Namelist to handle the content.
@@ -778,9 +784,14 @@ class Namelist(OrderedDict):
         if positional and isinstance(v_values, list):
             i_s = v_start[0] if v_start else 1
             for idx, val in enumerate(v_values, start=i_s):
-                if val is not None:
+                if val is None:
+                    continue
+                title = _join_attr(v_name, index=idx)
+                # Handle the full positional row first
+                if isinstance(val, Namelist) and '_positional_row' in val:
                     var_strs.extend(self._var_strings(
-                        _join_attr(v_name, index=idx), val))
+                        title, val['_positional_row']))
+                var_strs.extend(self._var_strings(title, val))
             return var_strs
 
         # Parse a multidimensional array
@@ -814,6 +825,10 @@ class Namelist(OrderedDict):
         # Parse derived type contents
         elif isinstance(v_values, Namelist):
             for f_name, f_vals in v_values.items():
+                # `_positional_row` is actual data, but handled elsewhere
+                if f_name == '_positional_row':
+                    continue
+
                 v_start_new = v_values.start_index.get(f_name, None)
 
                 # Handle derived type parent array indexing.  The bound

--- a/f90nml/namelist.py
+++ b/f90nml/namelist.py
@@ -108,6 +108,20 @@ class Namelist(OrderedDict):
 
         self.start_index = self.pop('_start_index', {})
 
+        # _positional: set of lowercase names that use positional assignment
+        # in the namelist
+        self._positional = set(self.pop('_positional', ()))
+
+        # _parent_indexed: set of lowercase names that come from a parent-indexed
+        # derived-type assignment
+        #
+        # Compare `ele_name` in these two cases:
+        #  1. `var(1:6)%ele_name = ...`.
+        #  2. `var%ele_name(1:6) = ...`.
+        #
+        #  (1) is parent-indexed, whereas (2) is not.
+        self._parent_indexed = set(self.pop('_parent_indexed', ()))
+
         # Update the complex tuples as intrinsics
         # TODO: We are effectively setting these twice.  Instead, fetch these
         # from s_args rather than relying on Namelist to handle the content.
@@ -550,6 +564,26 @@ class Namelist(OrderedDict):
         self._start_index = value
 
     @property
+    def positional(self):
+        """
+        Set of variable names stored as Fortran positional derived types.
+
+        :type: ``set[str]``
+        :default: ``set()``
+        """
+        return self._positional
+
+    @property
+    def parent_indexed(self):
+        """
+        Child names that should round-trip as ``parent(s:e)%child``.
+
+        :type: ``set[str]``
+        :default: ``set()``
+        """
+        return self._parent_indexed
+
+    @property
     def true_repr(self):
         """Set the string representation of logical true values.
 
@@ -726,21 +760,35 @@ class Namelist(OrderedDict):
         for v_name, v_val in grp_vars.items():
 
             v_start = grp_vars.start_index.get(v_name, None)
+            positional = v_name.lower() in grp_vars.positional
 
-            for v_str in self._var_strings(v_name, v_val, v_start=v_start):
+            for v_str in self._var_strings(v_name, v_val, v_start=v_start,
+                                           positional=positional):
                 print(v_str, file=nml_file)
 
         print('/', file=nml_file)
 
-    def _var_strings(self, v_name, v_values, v_idx=None, v_start=None):
+    def _var_strings(self, v_name, v_values, v_idx=None, v_start=None,
+                     positional=False, exclude_index=False):
         """Convert namelist variable to list of fixed-width strings."""
         if self.uppercase:
             v_name = v_name.upper()
 
         var_strs = []
 
+        # Positional derived-type form: one `var(idx) = v1` line per inner row.
+        # Each row is a flat list of mixed-type values.
+        if positional and is_nullable_list(v_values, list):
+            i_s = v_start[0] if v_start else 1
+            for idx, val in enumerate(v_values, start=i_s):
+                if val is not None:
+                    var_strs.extend(
+                        self._var_strings("{0}({1})".format(v_name, idx), val)
+                    )
+            return var_strs
+
         # Parse a multidimensional array
-        if is_nullable_list(v_values, list):
+        elif is_nullable_list(v_values, list):
             if not v_idx:
                 v_idx = []
 
@@ -770,9 +818,39 @@ class Namelist(OrderedDict):
         # Parse derived type contents
         elif isinstance(v_values, Namelist):
             for f_name, f_vals in v_values.items():
-                v_title = '%'.join([v_name, f_name])
-
                 v_start_new = v_values.start_index.get(f_name, None)
+
+                # Handle derived type parent array indexing
+                if (f_name.lower() in v_values.parent_indexed
+                        and isinstance(f_vals, list)):
+                    i_s = v_start_new[0] if v_start_new else 1
+
+                    # If there are any indices skipped, we have to go 1-by-1
+                    if any(v is None for v in f_vals):
+                        for offset, val in enumerate(f_vals):
+                            if val is not None:
+                                # parent_name(idx)%f_name
+                                sub = '{0}({1})%{2}'.format(
+                                    v_name, i_s + offset, f_name)
+                                v_strs = self._var_strings(sub, val)
+                                var_strs.extend(v_strs)
+                    else:
+                        i_e = i_s + len(f_vals) - 1
+                        if i_s == i_e:
+                            # single array element (start/end same)
+                            # parent_name(idx)%f_name
+                            sub = '{0}({1})%{2}'.format(
+                                v_name, i_s, f_name)
+                        else:
+                            # parent_name(start_idx:end_idx)%f_name
+                            sub = '{0}({1}:{2})%{3}'.format(
+                                v_name, i_s, i_e, f_name)
+                        v_strs = self._var_strings(sub, f_vals,
+                                                   exclude_index=True)
+                        var_strs.extend(v_strs)
+                    continue
+
+                v_title = '%'.join([v_name, f_name])
 
                 v_strs = self._var_strings(v_title, f_vals,
                                            v_start=v_start_new)
@@ -807,7 +885,9 @@ class Namelist(OrderedDict):
             # Print the index range
 
             # TODO: Include a check for len(v_values) to determine if vector
-            if v_idx or v_start or use_default_start_index:
+            if exclude_index:
+                v_idx_repr = ''
+            elif v_idx or v_start or use_default_start_index:
                 v_idx_repr = '('
 
                 if v_start or use_default_start_index:
@@ -976,9 +1056,13 @@ class Namelist(OrderedDict):
                     except KeyError:
                         nmldict['_complex'] = [key]
 
-        # Append the start index if present
+        # Append the start index, positional and parent-indexed flags if present
         if self.start_index:
             nmldict['_start_index'] = self.start_index
+        if self.positional:
+            nmldict['_positional'] = sorted(self.positional)
+        if self.parent_indexed:
+            nmldict['_parent_indexed'] = sorted(self.parent_indexed)
 
         return nmldict
 

--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -499,10 +499,15 @@ class Parser(object):
                 # along `dt_idx` to the `%` handler.
 
         elif parent_idx_bounds is not None:
-            # Index from parent derived type; treat as if the source
-            # were `<v_name>(start:end) = ...`.
-            v_idx_bounds = parent_idx_bounds
-            v_idx = self._record_indexed_var(parent, v_name, v_idx_bounds)
+            if self.token == '%':
+                # `parent(s:e)%inner%foo = ...`: this frame is `inner`,
+                #              ^^^^^  we are here at `inner`
+                child_idx_bounds = parent_idx_bounds
+                v_idx = None
+            else:
+                # Treat as if `<v_name>(start:end) = ...`.
+                v_idx_bounds = parent_idx_bounds
+                v_idx = self._record_indexed_var(parent, v_name, v_idx_bounds)
 
         else:
             v_idx = None
@@ -561,12 +566,17 @@ class Parser(object):
             )
 
             if child_idx_bounds is not None:
-                # Parent-indexed attribute - merge any data existing in the
-                # parent and then mark it as such.
+                # Parent-indexed: merge data from parent.
                 if v_att in v_parent:
                     v_att_vals = merge_values(v_parent[v_att], v_att_vals)
                 v_parent[v_att] = v_att_vals
-                v_parent.parent_indexed.add(v_att.lower())
+                if parent_idx_bounds is None:
+                    v_parent.parent_indexed.add(v_att.lower())
+                    if v_att.lower() not in v_parent.start_index:
+                        i_start = child_idx_bounds[0][0]
+                        if i_start is None:
+                            i_start = self.default_start_index
+                        v_parent.start_index[v_att.lower()] = [i_start]
                 self._append_value(v_values, v_parent, v_idx)
             else:
                 # Normal, child-indexed attribute

--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -437,7 +437,7 @@ class Parser(object):
 
         return nmls
 
-    def _parse_variable(self, parent, patch_nml=None):
+    def _parse_variable(self, parent, patch_nml=None, parent_idx_bounds=None):
         """Parse a variable and return its name and values."""
         if not patch_nml:
             patch_nml = Namelist()
@@ -451,35 +451,18 @@ class Parser(object):
         # Derived type parent index (see notes below)
         dt_idx = None
 
+        # Index bounds to associate with the next derived-type child
+        child_idx_bounds = None
+
+        # Saved multidimensional index for single-element indexed assignment
+        single_idx_v_idx = None  # type: FIndex | None
+
+        v_idx_bounds = None
+
         if self.token == '(':
 
             v_idx_bounds = self._parse_indices()
-            v_idx = FIndex(v_idx_bounds, self.global_start_index)
-
-            # Update starting index against namelist record
-            if v_name.lower() in parent.start_index:
-                p_idx = parent.start_index[v_name.lower()]
-
-                for idx, pv in enumerate(zip(p_idx, v_idx.first)):
-                    if all(i is None for i in pv):
-                        i_first = None
-                    else:
-                        i_first = min(i for i in pv if i is not None)
-
-                    v_idx.first[idx] = i_first
-
-                # Resize vector based on starting index
-                parent[v_name] = prepad_array(parent[v_name], p_idx,
-                                              v_idx.first)
-            else:
-                # If variable already existed without an index, then assume a
-                #   1-based index
-                # FIXME: Need to respect undefined `None` starting indexes?
-                if v_name in parent:
-                    v_idx.first = [self.default_start_index
-                                   for _ in v_idx.first]
-
-            parent.start_index[v_name.lower()] = v_idx.first
+            v_idx = self._record_indexed_var(parent, v_name, v_idx_bounds)
 
             self._update_tokens()
 
@@ -487,12 +470,39 @@ class Parser(object):
             # NOTE: This assumes single-dimension derived type vectors
             #       (which I think is the only case supported in Fortran)
             if self.token == '%':
-                assert v_idx_bounds[0][1] - v_idx_bounds[0][0] == 1
-                dt_idx = v_idx_bounds[0][0] - v_idx.first[0]
+                i_start, i_end, _ = v_idx_bounds[0]
+                is_single_elem = (
+                    i_start is not None
+                    and i_end is not None
+                    and i_end - i_start == 1
+                )
+                parent_is_dict = isinstance(
+                    parent.get(v_name.lower()), Namelist
+                )
+                if is_single_elem and not parent_is_dict:
+                    dt_idx = i_start - v_idx.first[0]
+                else:
+                    # Other cases:
+                    # * single element, parent dict
+                    # * multi element, parent dict
+                    # * multi element, not parent dict
+                    child_idx_bounds = v_idx_bounds
+
+                    # `arr(s:e)%foo` -> `arr%foo(s:e)`
+                    # Parent becomes a dict of arrays, start index moves to child.
+                    parent.start_index.pop(v_name.lower(), None)
+                    v_idx = None
+                    v_idx_bounds = None
 
                 # NOTE: This is the sensible play to call `parse_variable`
                 # but not yet sure how to implement it, so we currently pass
                 # along `dt_idx` to the `%` handler.
+
+        elif parent_idx_bounds is not None:
+            # Index from parent derived type; treat as if the source
+            # were `<v_name>(start:end) = ...`.
+            v_idx_bounds = parent_idx_bounds
+            v_idx = self._record_indexed_var(parent, v_name, v_idx_bounds)
 
         else:
             v_idx = None
@@ -546,12 +556,23 @@ class Parser(object):
 
             v_att, v_att_vals = self._parse_variable(
                 v_parent,
-                patch_nml=v_patch_nml
+                patch_nml=v_patch_nml,
+                parent_idx_bounds=child_idx_bounds
             )
 
-            next_value = Namelist()
-            next_value[v_att] = v_att_vals
-            self._append_value(v_values, next_value, v_idx)
+            if child_idx_bounds is not None:
+                # Parent-indexed attribute - merge any data existing in the
+                # parent and then mark it as such.
+                if v_att in v_parent:
+                    v_att_vals = merge_values(v_parent[v_att], v_att_vals)
+                v_parent[v_att] = v_att_vals
+                v_parent.parent_indexed.add(v_att.lower())
+                self._append_value(v_values, v_parent, v_idx)
+            else:
+                # Normal, child-indexed attribute
+                next_value = Namelist()
+                next_value[v_att] = v_att_vals
+                self._append_value(v_values, next_value, v_idx)
 
         else:
             # Construct the variable array
@@ -571,6 +592,13 @@ class Parser(object):
                     patch_values = [patch_values]
 
                 p_idx = 0
+
+            # `var(N) = v1, v2, ..., vK`: collect values flat and decide
+            # later whether to store as scalar (K=1) or as a Fortran
+            # positional derived-type row (K>1).
+            if v_idx is not None and _is_single_element_bound(v_idx_bounds):
+                single_idx_v_idx = v_idx
+                v_idx = None
 
             # Add variables until next variable trigger
             while (self.token not in ('=', '(', '%') or
@@ -660,9 +688,50 @@ class Parser(object):
         if patch_values:
             v_values = patch_values
 
+        # Single-element indexed assignment
+        if single_idx_v_idx is not None:
+            collected = v_values
+            v_values = []
+            if len(collected) > 1 and v_name is not None:
+                # Positional struct row (K>1)
+                parent.positional.add(v_name.lower())
+                self._append_value(v_values, list(collected), single_idx_v_idx)
+            else:
+                # Scalar at the index (K=1)
+                scalar = collected[0] if collected else None
+                self._append_value(v_values, scalar, single_idx_v_idx)
+            v_idx = single_idx_v_idx
+
         if not v_idx:
             v_values = delist(v_values)
         return v_name, v_values
+
+    def _record_indexed_var(self, parent, v_name, v_idx_bounds):
+        """Build the FIndex for an indexed assignment and update the parent."""
+        v_idx = FIndex(bounds=v_idx_bounds, first=self.global_start_index)
+
+        if v_name.lower() in parent.start_index:
+            p_idx = parent.start_index[v_name.lower()]
+
+            for idx, pv in enumerate(zip(p_idx, v_idx.first)):
+                if all(i is None for i in pv):
+                    i_first = None
+                else:
+                    i_first = min(i for i in pv if i is not None)
+
+                v_idx.first[idx] = i_first
+
+            parent[v_name] = prepad_array(parent[v_name], p_idx,
+                                          v_idx.first)
+        elif v_name in parent:
+            # If variable already existed without an index, then assume a
+            # 1-based index
+            # FIXME: Need to respect undefined `None` starting indexes?
+            # ^^ carried forward fixme from Parser._parse_variable
+            v_idx.first = [self.default_start_index for _ in v_idx.first]
+
+        parent.start_index[v_name.lower()] = v_idx.first
+        return v_idx
 
     def _parse_indices(self):
         """Parse a sequence of Fortran vector indices as a list of tuples."""
@@ -875,7 +944,7 @@ def prepad_array(var, v_start_idx, new_start_idx):
 
     # Apply prepad rules to interior arrays
     for i, v in enumerate(var):
-        if isinstance(v, list):
+        if isinstance(v, list) and len(v_start_idx) > 1:
             prior_var[i] = prepad_array(v, v_start_idx[:-1],
                                         new_start_idx[:-1])
     return pad + prior_var
@@ -952,6 +1021,14 @@ def delist(values):
         return values[0]
 
     return values
+
+
+def _is_single_element_bound(v_idx_bounds):
+    """Return True if `v_idx_bounds` describes a single fully-known index."""
+    if not v_idx_bounds or len(v_idx_bounds) != 1:
+        return False
+    start, end, _ = v_idx_bounds[0]
+    return start is not None and end is not None and end - start == 1
 
 
 def check_for_value(tokens):

--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -462,7 +462,7 @@ class Parser(object):
         scatter_idx_bounds = None
 
         # Saved multidimensional index for single-element indexed assignment
-        single_idx_v_idx = None  # type: FIndex | None
+        single_idx_v_idx = None
 
         v_idx_bounds = None
 
@@ -590,23 +590,14 @@ class Parser(object):
                         # `var(N)%field = ...`:
                         if (v_parent is not None
                                 and not isinstance(v_parent, Namelist)):
-                            prior = v_parent
-                            v_parent = Namelist()
-                            v_parent['_positional_row'] = (
-                                list(prior) if isinstance(prior, list)
-                                else [prior]
-                            )
+                            v_parent = _wrap_as_positional_row(v_parent)
                             vpar[dt_idx] = v_parent
                             parent.positional.add(v_name.lower())
                     elif vpar and not isinstance(vpar, Namelist):
                         # Unindexed case:
                         # `f = 1` then
                         # `f%x = 2`
-                        prior = vpar
-                        v_parent = Namelist()
-                        v_parent['_positional_row'] = (
-                            list(prior) if isinstance(prior, list) else [prior]
-                        )
+                        v_parent = _wrap_as_positional_row(vpar)
                         parent[v_name] = v_parent
                     elif vpar:
                         v_parent = vpar
@@ -1091,6 +1082,13 @@ def delist(values):
         return values[0]
 
     return values
+
+
+def _wrap_as_positional_row(value):
+    """Promote scalar/list value into a positional Namelist"""
+    nm = Namelist()
+    nm['_positional_row'] = list(value) if isinstance(value, list) else [value]
+    return nm
 
 
 def _is_single_element_bound(v_idx_bounds):

--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -437,7 +437,7 @@ class Parser(object):
 
         return nmls
 
-    def _parse_variable(self, parent, patch_nml=None, parent_idx_bounds=None):
+    def _parse_variable(self, parent, patch_nml=None):
         """Parse a variable and return its name and values."""
         if not patch_nml:
             patch_nml = Namelist()
@@ -451,14 +451,9 @@ class Parser(object):
         # Derived type parent index (see notes below)
         dt_idx = None
 
-        # Index bounds to associate with the next derived-type child
-        child_idx_bounds = None
-
-        # Index bounds when the values should be scattered across an
-        # existing list of derived-type elements:
-        #   `var(1:6)%attr = v1,...,v6` 
-        # after `var` has already been built up as a list of
-        # Namelists by prior `var(N)%...` assignments.
+        # Index bounds when the values of a derived-type array-section
+        # assignment should be scattered across a list of derived-type
+        # elements, e.g. `var(1:6)%attr = v1,...,v6` (see `_expand_section`).
         scatter_idx_bounds = None
 
         # Saved multidimensional index for single-element indexed assignment
@@ -485,38 +480,16 @@ class Parser(object):
                 )
                 existing = parent.get(v_name.lower())
                 parent_is_dict = isinstance(existing, Namelist)
-                parent_is_list = isinstance(existing, list)
                 if is_single_elem and not parent_is_dict:
+                    # `var(N)%field`: a single element of a derived-type
+                    # vector, handled below via `dt_idx`.
                     dt_idx = i_start - v_idx.first[0]
-                elif parent_is_list:
-                    # Multi-element range over an existing list of derived-type
-                    # elements
+                else:
+                    # `var(s:e)%field`: an array section of a derived-type
+                    # vector.
                     scatter_idx_bounds = v_idx_bounds
                     v_idx = None
                     v_idx_bounds = None
-                else:
-                    child_idx_bounds = v_idx_bounds
-
-                    # `arr(s:e)%foo` -> `arr%foo(s:e)`
-                    # Parent becomes a dict of arrays, start index moves to child.
-                    parent.start_index.pop(v_name.lower(), None)
-                    v_idx = None
-                    v_idx_bounds = None
-
-                # NOTE: This is the sensible play to call `parse_variable`
-                # but not yet sure how to implement it, so we currently pass
-                # along `dt_idx` to the `%` handler.
-
-        elif parent_idx_bounds is not None:
-            if self.token == '%':
-                # `parent(s:e)%inner%foo = ...`: this frame is `inner`,
-                #              ^^^^^  we are here at `inner`
-                child_idx_bounds = parent_idx_bounds
-                v_idx = None
-            else:
-                # Treat as if `<v_name>(start:end) = ...`.
-                v_idx_bounds = parent_idx_bounds
-                v_idx = self._record_indexed_var(parent, v_name, v_idx_bounds)
 
         else:
             v_idx = None
@@ -546,31 +519,30 @@ class Parser(object):
                 v_patch_nml = patch_nml.get(v_name.lower())
 
             if scatter_idx_bounds is not None:
-                self._update_tokens()
-                self._update_tokens()
+                # Walk the remaining component path `%a%b%...` that follows
+                # the array section.
+                v_att_path = []
+                while self.token == '%':
+                    self._update_tokens()
+                    v_att_path.append(self.token)
+                    self._update_tokens()
+                    if self.token == '(':
+                        raise ValueError(
+                            'f90nml: error: indexing an intermediate '
+                            'derived-type component of an array section '
+                            "('{0}') is not supported.".format(v_name)
+                        )
+
+                # Parse the assigned values as a plain (unindexed) list; the
+                # section bounds decide how they map onto array elements.
                 scratch = Namelist()
-                v_att, v_att_vals = self._parse_variable(
-                    scratch,
-                    patch_nml=v_patch_nml,
-                    parent_idx_bounds=scatter_idx_bounds
-                )
-                if not isinstance(v_att_vals, list):
-                    v_att_vals = [v_att_vals]
-                vpar = parent[v_name]
-                base = parent.start_index.get(
-                    v_name.lower(), [self.default_start_index])[0]
-                first = scatter_idx_bounds[0][0]
-                for k, val in enumerate(v_att_vals):
-                    idx = first + k - base
-                    while idx >= len(vpar):
-                        vpar.append(None)
-                    if not isinstance(vpar[idx], Namelist):
-                        vpar[idx] = Namelist()
-                    vpar[idx][v_att] = val
-                # Make sure the writer emits slices for this, since the
-                # input was a slice:
-                parent.sliced_attrs.setdefault(
-                    v_name.lower(), set()).add(v_att.lower())
+                _, raw_vals = self._parse_variable(
+                    scratch, patch_nml=v_patch_nml)
+                sec_vals = (raw_vals if isinstance(raw_vals, list)
+                            else [raw_vals])
+
+                self._expand_section(
+                    parent, v_name, scatter_idx_bounds, v_att_path, sec_vals)
 
             else:
                 if parent:
@@ -586,10 +558,14 @@ class Parser(object):
                         except IndexError:
                             v_parent = Namelist()
 
-                        # `var(N) = "string"` and then
-                        # `var(N)%field = ...`:
-                        if (v_parent is not None
-                                and not isinstance(v_parent, Namelist)):
+                        if v_parent is None:
+                            # A gap left by an earlier, higher-indexed
+                            # element assignment (e.g. `var(2)%x` before
+                            # `var(1)%attr`).
+                            v_parent = Namelist()
+                        elif not isinstance(v_parent, Namelist):
+                            # `var(N) = "string"` and then
+                            # `var(N)%field = ...`:
                             v_parent = _wrap_as_positional_row(v_parent)
                             vpar[dt_idx] = v_parent
                             parent.positional.add(v_name.lower())
@@ -613,27 +589,11 @@ class Parser(object):
                 v_att, v_att_vals = self._parse_variable(
                     v_parent,
                     patch_nml=v_patch_nml,
-                    parent_idx_bounds=child_idx_bounds
                 )
 
-                if child_idx_bounds is not None:
-                    # Parent-indexed: merge data from parent.
-                    if v_att in v_parent:
-                        v_att_vals = merge_values(v_parent[v_att], v_att_vals)
-                    v_parent[v_att] = v_att_vals
-                    if parent_idx_bounds is None:
-                        v_parent.parent_indexed.add(v_att.lower())
-                        if v_att.lower() not in v_parent.start_index:
-                            i_start = child_idx_bounds[0][0]
-                            if i_start is None:
-                                i_start = self.default_start_index
-                            v_parent.start_index[v_att.lower()] = [i_start]
-                    self._append_value(v_values, v_parent, v_idx)
-                else:
-                    # Normal, child-indexed attribute
-                    next_value = Namelist()
-                    next_value[v_att] = v_att_vals
-                    self._append_value(v_values, next_value, v_idx)
+                next_value = Namelist()
+                next_value[v_att] = v_att_vals
+                self._append_value(v_values, next_value, v_idx)
 
         else:
             # Construct the variable array
@@ -766,6 +726,53 @@ class Parser(object):
         if not v_idx:
             v_values = delist(v_values)
         return v_name, v_values
+
+    def _expand_section(self, parent, v_name, sec_bounds, path, values):
+        """Scatter `values` across a list of derived-type elements.
+
+        Distributes each value of an array-section assignment
+        `v_name(s:e)%path = values` to the corresponding element of a list of
+        Namelists under `v_name`, creating or extending the list as needed.
+        """
+        start, _end, stride = sec_bounds[0]
+        if start is None:
+            start = self.default_start_index
+        if stride is None:
+            stride = 1
+
+        existing = parent.get(v_name.lower())
+        if isinstance(existing, list):
+            vpar = existing
+            base = parent.start_index.get(
+                v_name.lower(), [self.default_start_index])[0]
+        else:
+            vpar = []
+            base = start
+
+        for k, val in enumerate(values):
+            pos = (start - base) + k * stride
+            while pos >= len(vpar):
+                vpar.append(None)
+            if not isinstance(vpar[pos], Namelist):
+                vpar[pos] = Namelist()
+
+            node = vpar[pos]
+            for name in path[:-1]:
+                child = node.get(name.lower())
+                if not isinstance(child, Namelist):
+                    child = Namelist()
+                    node[name] = child
+                node = child
+            node[path[-1]] = val
+
+        parent[v_name] = vpar
+        parent.start_index[v_name.lower()] = [base]
+
+        # Preserve the compact `v_name(s:e)%attr = ...` slice form on output
+        # for a terminal, single-level component.
+        if len(path) == 1:
+            parent.sliced_attrs.setdefault(
+                v_name.lower(), set()).add(path[0].lower())
 
     def _record_indexed_var(self, parent, v_name, v_idx_bounds):
         """Build the FIndex for an indexed assignment and update the parent."""

--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -454,6 +454,13 @@ class Parser(object):
         # Index bounds to associate with the next derived-type child
         child_idx_bounds = None
 
+        # Index bounds when the values should be scattered across an
+        # existing list of derived-type elements:
+        #   `var(1:6)%attr = v1,...,v6` 
+        # after `var` has already been built up as a list of
+        # Namelists by prior `var(N)%...` assignments.
+        scatter_idx_bounds = None
+
         # Saved multidimensional index for single-element indexed assignment
         single_idx_v_idx = None  # type: FIndex | None
 
@@ -476,16 +483,18 @@ class Parser(object):
                     and i_end is not None
                     and i_end - i_start == 1
                 )
-                parent_is_dict = isinstance(
-                    parent.get(v_name.lower()), Namelist
-                )
+                existing = parent.get(v_name.lower())
+                parent_is_dict = isinstance(existing, Namelist)
+                parent_is_list = isinstance(existing, list)
                 if is_single_elem and not parent_is_dict:
                     dt_idx = i_start - v_idx.first[0]
+                elif parent_is_list:
+                    # Multi-element range over an existing list of derived-type
+                    # elements
+                    scatter_idx_bounds = v_idx_bounds
+                    v_idx = None
+                    v_idx_bounds = None
                 else:
-                    # Other cases:
-                    # * single element, parent dict
-                    # * multi element, parent dict
-                    # * multi element, not parent dict
                     child_idx_bounds = v_idx_bounds
 
                     # `arr(s:e)%foo` -> `arr%foo(s:e)`
@@ -536,74 +545,104 @@ class Parser(object):
             if v_name in patch_nml:
                 v_patch_nml = patch_nml.get(v_name.lower())
 
-            if parent:
-                vpar = parent.get(v_name.lower())
-                if vpar and isinstance(vpar, list):
-                    # If new element is not a list, then assume it's the first
-                    # element of the list.
-                    if dt_idx is None:
-                        dt_idx = self.default_start_index
+            if scatter_idx_bounds is not None:
+                self._update_tokens()
+                self._update_tokens()
+                scratch = Namelist()
+                v_att, v_att_vals = self._parse_variable(
+                    scratch,
+                    patch_nml=v_patch_nml,
+                    parent_idx_bounds=scatter_idx_bounds
+                )
+                if not isinstance(v_att_vals, list):
+                    v_att_vals = [v_att_vals]
+                vpar = parent[v_name]
+                base = parent.start_index.get(
+                    v_name.lower(), [self.default_start_index])[0]
+                first = scatter_idx_bounds[0][0]
+                for k, val in enumerate(v_att_vals):
+                    idx = first + k - base
+                    while idx >= len(vpar):
+                        vpar.append(None)
+                    if not isinstance(vpar[idx], Namelist):
+                        vpar[idx] = Namelist()
+                    vpar[idx][v_att] = val
+                # Make sure the writer emits slices for this, since the
+                # input was a slice:
+                parent.sliced_attrs.setdefault(
+                    v_name.lower(), set()).add(v_att.lower())
 
-                    try:
-                        v_parent = vpar[dt_idx]
-                    except IndexError:
-                        v_parent = Namelist()
+            else:
+                if parent:
+                    vpar = parent.get(v_name.lower())
+                    if vpar and isinstance(vpar, list):
+                        # If new element is not a list, then assume it's the first
+                        # element of the list.
+                        if dt_idx is None:
+                            dt_idx = self.default_start_index
 
-                    # `var(N) = "string"` and then
-                    # `var(N)%field = ...`:
-                    if v_parent is not None and not isinstance(v_parent, Namelist):
-                        prior = v_parent
+                        try:
+                            v_parent = vpar[dt_idx]
+                        except IndexError:
+                            v_parent = Namelist()
+
+                        # `var(N) = "string"` and then
+                        # `var(N)%field = ...`:
+                        if (v_parent is not None
+                                and not isinstance(v_parent, Namelist)):
+                            prior = v_parent
+                            v_parent = Namelist()
+                            v_parent['_positional_row'] = (
+                                list(prior) if isinstance(prior, list)
+                                else [prior]
+                            )
+                            vpar[dt_idx] = v_parent
+                            parent.positional.add(v_name.lower())
+                    elif vpar and not isinstance(vpar, Namelist):
+                        # Unindexed case:
+                        # `f = 1` then
+                        # `f%x = 2`
+                        prior = vpar
                         v_parent = Namelist()
                         v_parent['_positional_row'] = (
                             list(prior) if isinstance(prior, list) else [prior]
                         )
-                        vpar[dt_idx] = v_parent
-                        parent.positional.add(v_name.lower())
-                elif vpar and not isinstance(vpar, Namelist):
-                    # Unindexed case:
-                    # `f = 1` then 
-                    # `f%x = 2`
-                    prior = vpar
-                    v_parent = Namelist()
-                    v_parent['_positional_row'] = (
-                        list(prior) if isinstance(prior, list) else [prior]
-                    )
-                    parent[v_name] = v_parent
-                elif vpar:
-                    v_parent = vpar
+                        parent[v_name] = v_parent
+                    elif vpar:
+                        v_parent = vpar
+                    else:
+                        v_parent = Namelist()
                 else:
                     v_parent = Namelist()
-            else:
-                v_parent = Namelist()
-                parent[v_name] = v_parent
+                    parent[v_name] = v_parent
 
-            self._update_tokens()
-            self._update_tokens()
+                self._update_tokens()
+                self._update_tokens()
 
-            v_att, v_att_vals = self._parse_variable(
-                v_parent,
-                patch_nml=v_patch_nml,
-                parent_idx_bounds=child_idx_bounds
-            )
+                v_att, v_att_vals = self._parse_variable(
+                    v_parent,
+                    patch_nml=v_patch_nml,
+                    parent_idx_bounds=child_idx_bounds
+                )
 
-            if child_idx_bounds is not None:
-                # Parent-indexed: merge data from parent.
-                if v_att in v_parent:
-                    v_att_vals = merge_values(v_parent[v_att], v_att_vals)
-                v_parent[v_att] = v_att_vals
-                if parent_idx_bounds is None:
-                    v_parent.parent_indexed.add(v_att.lower())
-                    if v_att.lower() not in v_parent.start_index:
-                        i_start = child_idx_bounds[0][0]
-                        if i_start is None:
-                            i_start = self.default_start_index
-                        v_parent.start_index[v_att.lower()] = [i_start]
-                self._append_value(v_values, v_parent, v_idx)
-            else:
-                # Normal, child-indexed attribute
-                next_value = Namelist()
-                next_value[v_att] = v_att_vals
-                self._append_value(v_values, next_value, v_idx)
+                if child_idx_bounds is not None:
+                    # Parent-indexed: merge data from parent.
+                    if v_att in v_parent:
+                        v_att_vals = merge_values(v_parent[v_att], v_att_vals)
+                    v_parent[v_att] = v_att_vals
+                    if parent_idx_bounds is None:
+                        v_parent.parent_indexed.add(v_att.lower())
+                        if v_att.lower() not in v_parent.start_index:
+                            i_start = child_idx_bounds[0][0]
+                            if i_start is None:
+                                i_start = self.default_start_index
+                            v_parent.start_index[v_att.lower()] = [i_start]
+                    self._append_value(v_values, v_parent, v_idx)
+                else:
+                    # Normal, child-indexed attribute
+                    next_value = Namelist()
+                    next_value[v_att] = v_att_vals
+                    self._append_value(v_values, next_value, v_idx)
 
         else:
             # Construct the variable array

--- a/f90nml/parser.py
+++ b/f90nml/parser.py
@@ -548,6 +548,27 @@ class Parser(object):
                         v_parent = vpar[dt_idx]
                     except IndexError:
                         v_parent = Namelist()
+
+                    # `var(N) = "string"` and then
+                    # `var(N)%field = ...`:
+                    if v_parent is not None and not isinstance(v_parent, Namelist):
+                        prior = v_parent
+                        v_parent = Namelist()
+                        v_parent['_positional_row'] = (
+                            list(prior) if isinstance(prior, list) else [prior]
+                        )
+                        vpar[dt_idx] = v_parent
+                        parent.positional.add(v_name.lower())
+                elif vpar and not isinstance(vpar, Namelist):
+                    # Unindexed case:
+                    # `f = 1` then 
+                    # `f%x = 2`
+                    prior = vpar
+                    v_parent = Namelist()
+                    v_parent['_positional_row'] = (
+                        list(prior) if isinstance(prior, list) else [prior]
+                    )
+                    parent[v_name] = v_parent
                 elif vpar:
                     v_parent = vpar
                 else:

--- a/tests/dtype.nml
+++ b/tests/dtype.nml
@@ -75,6 +75,16 @@
     datum(2) = 'alpha.a', '', '', 'M1', 'target', 6.7, 1e2
 /
 
+&dtype_positional_mixed_nml
+    datum(1) = 'eta.x', '', 'M1', 'target', 1.2, 1e2
+    datum(2)%data_type = 'expression: a - b'
+    datum(2)%meas = 0.0
+    datum(2)%weight = 1.0
+    datum(3)%data_type = 'expression: c - d'
+    datum(3)%meas = 0.0
+    datum(3)%weight = 1.0
+/
+
 &dtype_nested_parent_idx_nml
     arr(1:2)%inner%foo = 1.0, 2.0
 /

--- a/tests/dtype.nml
+++ b/tests/dtype.nml
@@ -149,3 +149,11 @@
     datum(1) = 'a', 1
     datum(3) = 'b', 2
 /
+
+&config_issue_185
+  settings(:)%flag = .true., .false.
+/
+
+&config_issue_185_unsectioned
+  settings%flag = .true., .false.
+/

--- a/tests/dtype.nml
+++ b/tests/dtype.nml
@@ -95,6 +95,13 @@
     f%x = 42
 /
 
+&dtype_scatter_over_dt_array_nml
+    var(1)%ele_name = 'a'
+    var(2)%ele_name = 'b'
+    var(3)%ele_name = 'c'
+    var(1:3)%attribute = 'k1', 'k2', 'k3'
+/
+
 &dtype_nested_parent_idx_nml
     arr(1:2)%inner%foo = 1.0, 2.0
 /

--- a/tests/dtype.nml
+++ b/tests/dtype.nml
@@ -90,6 +90,11 @@
     design_lattice(1)%dynamic_aperture_calc = .true.
 /
 
+&dtype_unindexed_positional_then_field_nml
+    f = 'hello'
+    f%x = 42
+/
+
 &dtype_nested_parent_idx_nml
     arr(1:2)%inner%foo = 1.0, 2.0
 /

--- a/tests/dtype.nml
+++ b/tests/dtype.nml
@@ -85,6 +85,11 @@
     datum(3)%weight = 1.0
 /
 
+&dtype_positional_then_field_nml
+    design_lattice(1) = 'bmad.lat'
+    design_lattice(1)%dynamic_aperture_calc = .true.
+/
+
 &dtype_nested_parent_idx_nml
     arr(1:2)%inner%foo = 1.0, 2.0
 /

--- a/tests/dtype.nml
+++ b/tests/dtype.nml
@@ -123,3 +123,29 @@
 &dtype_strided_parent_idx_nml
     arr(1:5:2)%foo = 10.0, 30.0, 50.0
 /
+
+&dtype_scatter_partial_nml
+    var(1)%x = 1
+    var(2:3)%attr = 'a', 'b'
+/
+
+&dtype_scatter_irregular_nml
+    var(1)%attr = 'a'
+    var(2)%x = 2
+    var(3:4)%attr = 'c', 'd'
+/
+
+&dtype_scatter_nested_nml
+    var(1)%x = 1
+    var(2)%x = 2
+    var(1:2)%inner%foo = 1.0, 2.0
+/
+
+&dtype_open_start_parent_idx_nml
+    arr(:2)%inner%foo = 1.0, 2.0
+/
+
+&dtype_positional_gap_nml
+    datum(1) = 'a', 1
+    datum(3) = 'b', 2
+/

--- a/tests/dtype.nml
+++ b/tests/dtype.nml
@@ -74,3 +74,25 @@
     datum(1) = 'beta.a',  '', '', 'M1', 'target', 4.5, 1e1
     datum(2) = 'alpha.a', '', '', 'M1', 'target', 6.7, 1e2
 /
+
+&dtype_nested_parent_idx_nml
+    arr(1:2)%inner%foo = 1.0, 2.0
+/
+
+&dtype_nested_parent_idx_multi_nml
+    arr(1:2)%inner%foo = 1.0, 2.0
+    arr(1:2)%inner%bar = 3.0, 4.0
+/
+
+&dtype_triple_nested_parent_idx_nml
+    arr(1:2)%a%b%c = 1.0, 2.0
+/
+
+&dtype_mixed_flat_then_nested_nml
+    arr(1:2)%foo = 1.0, 2.0
+    arr(1:2)%inner%bar = 3.0, 4.0
+/
+
+&dtype_strided_parent_idx_nml
+    arr(1:5:2)%foo = 10.0, 30.0, 50.0
+/

--- a/tests/dtype.nml
+++ b/tests/dtype.nml
@@ -49,3 +49,28 @@
     a%i = 123
     a(3)%i = 789
 /
+
+&dtype_vec_range_nml
+    arr(1:2)%foo =   1.0,   2.0
+    arr(1:2)%bar =   3.0,   4.0
+/
+
+&dtype_vec_open_range_nml
+    var(1:)%ele_name = 'P1_PIP5', 'M2_PIP0'
+/
+
+&dtype_vec_open_range_single_nml
+    var(1:)%ele_name = 'O_L1'
+/
+
+&dtype_vec_range_then_single_nml
+    var(1:6)%ele_name  = 'a' 'b' 'c' 'd' 'e' 'f'
+    var(1:6)%attribute = 'p' 'q' 'r' 's' 't' 'u'
+    var(1)%low_lim = 0.001
+    var(3)%low_lim = 0.001
+/
+
+&dtype_positional_nml
+    datum(1) = 'beta.a',  '', '', 'M1', 'target', 4.5, 1e1
+    datum(2) = 'alpha.a', '', '', 'M1', 'target', 6.7, 1e2
+/

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -64,8 +64,7 @@
 &dtype_vec_range_then_single_nml
     var(1:6)%ele_name = 'a', 'b', 'c', 'd', 'e', 'f'
     var(1:6)%attribute = 'p', 'q', 'r', 's', 't', 'u'
-    var(1)%low_lim = 0.001
-    var(3)%low_lim = 0.001
+    var(1:3:2)%low_lim = 0.001, 0.001
 /
 
 &dtype_positional_nml
@@ -112,7 +111,5 @@
 /
 
 &dtype_strided_parent_idx_nml
-    arr(1)%foo = 10.0
-    arr(3)%foo = 30.0
-    arr(5)%foo = 50.0
+    arr(1:5:2)%foo = 10.0, 30.0, 50.0
 /

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -49,8 +49,8 @@
 /
 
 &dtype_vec_range_nml
-    arr(1:2)%foo = 1.0, 2.0
     arr(1:2)%bar = 3.0, 4.0
+    arr(1:2)%foo = 1.0, 2.0
 /
 
 &dtype_vec_open_range_nml
@@ -62,9 +62,10 @@
 /
 
 &dtype_vec_range_then_single_nml
-    var(1:6)%ele_name = 'a', 'b', 'c', 'd', 'e', 'f'
+    var(1)%low_lim = 0.001
+    var(3)%low_lim = 0.001
     var(1:6)%attribute = 'p', 'q', 'r', 's', 't', 'u'
-    var(1:3:2)%low_lim = 0.001, 0.001
+    var(1:6)%ele_name = 'a', 'b', 'c', 'd', 'e', 'f'
 /
 
 &dtype_positional_nml
@@ -100,21 +101,26 @@
 /
 
 &dtype_nested_parent_idx_nml
-    arr(1:2)%inner%foo = 1.0, 2.0
+    arr(1)%inner%foo = 1.0
+    arr(2)%inner%foo = 2.0
 /
 
 &dtype_nested_parent_idx_multi_nml
-    arr(1:2)%inner%foo = 1.0, 2.0
-    arr(1:2)%inner%bar = 3.0, 4.0
+    arr(1)%inner%foo = 1.0
+    arr(1)%inner%bar = 3.0
+    arr(2)%inner%foo = 2.0
+    arr(2)%inner%bar = 4.0
 /
 
 &dtype_triple_nested_parent_idx_nml
-    arr(1:2)%a%b%c = 1.0, 2.0
+    arr(1)%a%b%c = 1.0
+    arr(2)%a%b%c = 2.0
 /
 
 &dtype_mixed_flat_then_nested_nml
+    arr(1)%inner%bar = 3.0
+    arr(2)%inner%bar = 4.0
     arr(1:2)%foo = 1.0, 2.0
-    arr(1:2)%inner%bar = 3.0, 4.0
 /
 
 &dtype_strided_parent_idx_nml
@@ -136,12 +142,14 @@
 
 &dtype_scatter_nested_nml
     var(1)%x = 1
+    var(1)%inner%foo = 1.0
     var(2)%x = 2
-    var(1)%inner%foo(1:2) = 1.0, 2.0
+    var(2)%inner%foo = 2.0
 /
 
 &dtype_open_start_parent_idx_nml
-    arr(1:2)%inner%foo = 1.0, 2.0
+    arr(1)%inner%foo = 1.0
+    arr(2)%inner%foo = 2.0
 /
 
 &dtype_positional_gap_nml

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -83,6 +83,11 @@
     datum(3)%weight = 1.0
 /
 
+&dtype_positional_then_field_nml
+    design_lattice(1) = 'bmad.lat'
+    design_lattice(1)%dynamic_aperture_calc = .true.
+/
+
 &dtype_nested_parent_idx_nml
     arr(1:2)%inner%foo = 1.0, 2.0
 /

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -88,6 +88,11 @@
     design_lattice(1)%dynamic_aperture_calc = .true.
 /
 
+&dtype_unindexed_positional_then_field_nml
+    f = 'hello'
+    f%x = 42
+/
+
 &dtype_nested_parent_idx_nml
     arr(1:2)%inner%foo = 1.0, 2.0
 /

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -120,3 +120,31 @@
 &dtype_strided_parent_idx_nml
     arr(1:5:2)%foo = 10.0, 30.0, 50.0
 /
+
+&dtype_scatter_partial_nml
+    var(1)%x = 1
+    var(2)%attr = 'a'
+    var(3)%attr = 'b'
+/
+
+&dtype_scatter_irregular_nml
+    var(2)%x = 2
+    var(1)%attr = 'a'
+    var(3)%attr = 'c'
+    var(4)%attr = 'd'
+/
+
+&dtype_scatter_nested_nml
+    var(1)%x = 1
+    var(2)%x = 2
+    var(1)%inner%foo(1:2) = 1.0, 2.0
+/
+
+&dtype_open_start_parent_idx_nml
+    arr(1:2)%inner%foo = 1.0, 2.0
+/
+
+&dtype_positional_gap_nml
+    datum(1) = 'a', 1
+    datum(3) = 'b', 2
+/

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -73,6 +73,16 @@
     datum(2) = 'alpha.a', '', '', 'M1', 'target', 6.7, 100.0
 /
 
+&dtype_positional_mixed_nml
+    datum(1) = 'eta.x', '', 'M1', 'target', 1.2, 100.0
+    datum(2)%data_type = 'expression: a - b'
+    datum(2)%meas = 0.0
+    datum(2)%weight = 1.0
+    datum(3)%data_type = 'expression: c - d'
+    datum(3)%meas = 0.0
+    datum(3)%weight = 1.0
+/
+
 &dtype_nested_parent_idx_nml
     arr(1:2)%inner%foo = 1.0, 2.0
 /

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -92,6 +92,13 @@
     f%x = 42
 /
 
+&dtype_scatter_over_dt_array_nml
+    var(1)%ele_name = 'a'
+    var(2)%ele_name = 'b'
+    var(3)%ele_name = 'c'
+    var(1:3)%attribute = 'k1', 'k2', 'k3'
+/
+
 &dtype_nested_parent_idx_nml
     arr(1:2)%inner%foo = 1.0, 2.0
 /

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -47,3 +47,28 @@
     a(2)%i = 456
     a(3)%i = 789
 /
+
+&dtype_vec_range_nml
+    arr(1:2)%foo = 1.0, 2.0
+    arr(1:2)%bar = 3.0, 4.0
+/
+
+&dtype_vec_open_range_nml
+    var(1:2)%ele_name = 'P1_PIP5', 'M2_PIP0'
+/
+
+&dtype_vec_open_range_single_nml
+    var(1)%ele_name = 'O_L1'
+/
+
+&dtype_vec_range_then_single_nml
+    var(1:6)%ele_name = 'a', 'b', 'c', 'd', 'e', 'f'
+    var(1:6)%attribute = 'p', 'q', 'r', 's', 't', 'u'
+    var(1)%low_lim = 0.001
+    var(3)%low_lim = 0.001
+/
+
+&dtype_positional_nml
+    datum(1) = 'beta.a', '', '', 'M1', 'target', 4.5, 10.0
+    datum(2) = 'alpha.a', '', '', 'M1', 'target', 6.7, 100.0
+/

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -156,3 +156,11 @@
     datum(1) = 'a', 1
     datum(3) = 'b', 2
 /
+
+&config_issue_185
+    settings(1:2)%flag = .true., .false.
+/
+
+&config_issue_185_unsectioned
+    settings%flag = .true., .false.
+/

--- a/tests/dtype_target.nml
+++ b/tests/dtype_target.nml
@@ -72,3 +72,27 @@
     datum(1) = 'beta.a', '', '', 'M1', 'target', 4.5, 10.0
     datum(2) = 'alpha.a', '', '', 'M1', 'target', 6.7, 100.0
 /
+
+&dtype_nested_parent_idx_nml
+    arr(1:2)%inner%foo = 1.0, 2.0
+/
+
+&dtype_nested_parent_idx_multi_nml
+    arr(1:2)%inner%foo = 1.0, 2.0
+    arr(1:2)%inner%bar = 3.0, 4.0
+/
+
+&dtype_triple_nested_parent_idx_nml
+    arr(1:2)%a%b%c = 1.0, 2.0
+/
+
+&dtype_mixed_flat_then_nested_nml
+    arr(1:2)%foo = 1.0, 2.0
+    arr(1:2)%inner%bar = 3.0, 4.0
+/
+
+&dtype_strided_parent_idx_nml
+    arr(1)%foo = 10.0
+    arr(3)%foo = 30.0
+    arr(5)%foo = 50.0
+/

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -358,6 +358,13 @@ class Test(unittest.TestCase):
                     'x': 42,
                 },
             },
+            'dtype_scatter_over_dt_array_nml': {
+                'var': [
+                    {'ele_name': 'a', 'attribute': 'k1'},
+                    {'ele_name': 'b', 'attribute': 'k2'},
+                    {'ele_name': 'c', 'attribute': 'k3'},
+                ],
+            },
             'dtype_nested_parent_idx_nml': {
                 'arr': {
                     'inner': {

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -300,6 +300,35 @@ class Test(unittest.TestCase):
                     {'i': 789},
                 ],
             },
+            'dtype_vec_range_nml': {
+                'arr': {
+                    'foo': [1.0, 2.0],
+                    'bar': [3.0, 4.0],
+                },
+            },
+            'dtype_vec_open_range_nml': {
+                'var': {
+                    'ele_name': ['P1_PIP5', 'M2_PIP0'],
+                },
+            },
+            'dtype_vec_open_range_single_nml': {
+                'var': {
+                    'ele_name': ['O_L1'],
+                },
+            },
+            'dtype_vec_range_then_single_nml': {
+                'var': {
+                    'ele_name': ['a', 'b', 'c', 'd', 'e', 'f'],
+                    'attribute': ['p', 'q', 'r', 's', 't', 'u'],
+                    'low_lim': [0.001, None, 0.001],
+                },
+            },
+            'dtype_positional_nml': {
+                'datum': [
+                    ['beta.a', '', '', 'M1', 'target', 4.5, 10.0],
+                    ['alpha.a', '', '', 'M1', 'target', 6.7, 100.0],
+                ],
+            },
         }
 
         self.dtype_case_nml = {

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -352,6 +352,12 @@ class Test(unittest.TestCase):
                     },
                 ],
             },
+            'dtype_unindexed_positional_then_field_nml': {
+                'f': {
+                    '_positional_row': ['hello'],
+                    'x': 42,
+                },
+            },
             'dtype_nested_parent_idx_nml': {
                 'arr': {
                     'inner': {

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -329,6 +329,21 @@ class Test(unittest.TestCase):
                     ['alpha.a', '', '', 'M1', 'target', 6.7, 100.0],
                 ],
             },
+            'dtype_positional_mixed_nml': {
+                'datum': [
+                    ['eta.x', '', 'M1', 'target', 1.2, 100.0],
+                    {
+                        'data_type': 'expression: a - b',
+                        'meas': 0.0,
+                        'weight': 1.0,
+                    },
+                    {
+                        'data_type': 'expression: c - d',
+                        'meas': 0.0,
+                        'weight': 1.0,
+                    },
+                ],
+            },
             'dtype_nested_parent_idx_nml': {
                 'arr': {
                     'inner': {
@@ -1360,6 +1375,14 @@ class Test(unittest.TestCase):
         source_str = self.get_cli_output(cmd)
 
         with open('types.nml') as target:
+            target_str = target.read()
+            self.assertEqual(source_str, target_str)
+
+    def test_cli_dtype_roundtrip(self):
+        cmd = ['f90nml', 'dtype.nml']
+        source_str = self.get_cli_output(cmd)
+
+        with open('dtype_target.nml') as target:
             target_str = target.read()
             self.assertEqual(source_str, target_str)
 

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -432,6 +432,15 @@ class Test(unittest.TestCase):
             'dtype_positional_gap_nml': {
                 'datum': [['a', 1], None, ['b', 2]],
             },
+            'config_issue_185': {
+                'settings': [
+                    {'flag': True},
+                    {'flag': False},
+                ]
+            },
+            'config_issue_185_unsectioned': {
+                'settings': {'flag': [True, False]},
+            },
         }
 
         self.dtype_case_nml = {
@@ -838,6 +847,38 @@ class Test(unittest.TestCase):
         test_nml = f90nml.read('dtype.nml')
         self.assertEqual(self.dtype_nml, test_nml)
         self.assert_write(test_nml, 'dtype_target.nml')
+
+    def test_array_section_component_forms(self):
+        cases = {
+            's(1:2)%flag = .true., .false.':
+                [{'flag': True}, {'flag': False}],
+            's(:)%flag = .true., .false.':
+                [{'flag': True}, {'flag': False}],
+            's(1:5:2)%x = 10.0, 30.0, 50.0':
+                [{'x': 10.0}, None, {'x': 30.0}, None, {'x': 50.0}],
+            's(1:2)%inner%foo = 1.0, 2.0':
+                [{'inner': {'foo': 1.0}}, {'inner': {'foo': 2.0}}],
+        }
+        for text, expected in cases.items():
+            nml = f90nml.reads("&g\n  {0}\n/\n".format(text))
+            self.assertEqual({'g': {'s': expected}}, nml, msg=text)
+
+    def test_array_section_component_edge_cases(self):
+        # Higher index first -> lower index second
+        nml = f90nml.reads(
+            '&g\n'
+            "  v(2)%x = 2\n"
+            "  v(1)%attr = 'a'\n"
+            '/\n'
+        )
+        self.assertEqual({'g': {'v': [{'attr': 'a'}, {'x': 2}]}}, nml)
+
+        # Indexing an intermediate component of a section is unsupported.
+        self.assertRaises(
+            ValueError,
+            f90nml.reads,
+            '&g\n  a(1:2)%inner(3)%foo = 1.0, 2.0\n/\n',
+        )
 
     def test_ieee(self):
         test_nml = f90nml.read('ieee.nml')

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -344,6 +344,14 @@ class Test(unittest.TestCase):
                     },
                 ],
             },
+            'dtype_positional_then_field_nml': {
+                'design_lattice': [
+                    {
+                        '_positional_row': ['bmad.lat'],
+                        'dynamic_aperture_calc': True,
+                    },
+                ],
+            },
             'dtype_nested_parent_idx_nml': {
                 'arr': {
                     'inner': {

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -301,27 +301,31 @@ class Test(unittest.TestCase):
                 ],
             },
             'dtype_vec_range_nml': {
-                'arr': {
-                    'foo': [1.0, 2.0],
-                    'bar': [3.0, 4.0],
-                },
+                'arr': [
+                    {'foo': 1.0, 'bar': 3.0},
+                    {'foo': 2.0, 'bar': 4.0},
+                ],
             },
             'dtype_vec_open_range_nml': {
-                'var': {
-                    'ele_name': ['P1_PIP5', 'M2_PIP0'],
-                },
+                'var': [
+                    {'ele_name': 'P1_PIP5'},
+                    {'ele_name': 'M2_PIP0'},
+                ],
             },
             'dtype_vec_open_range_single_nml': {
-                'var': {
-                    'ele_name': ['O_L1'],
-                },
+                'var': [
+                    {'ele_name': 'O_L1'},
+                ],
             },
             'dtype_vec_range_then_single_nml': {
-                'var': {
-                    'ele_name': ['a', 'b', 'c', 'd', 'e', 'f'],
-                    'attribute': ['p', 'q', 'r', 's', 't', 'u'],
-                    'low_lim': [0.001, None, 0.001],
-                },
+                'var': [
+                    {'ele_name': 'a', 'attribute': 'p', 'low_lim': 0.001},
+                    {'ele_name': 'b', 'attribute': 'q'},
+                    {'ele_name': 'c', 'attribute': 'r', 'low_lim': 0.001},
+                    {'ele_name': 'd', 'attribute': 's'},
+                    {'ele_name': 'e', 'attribute': 't'},
+                    {'ele_name': 'f', 'attribute': 'u'},
+                ],
             },
             'dtype_positional_nml': {
                 'datum': [
@@ -366,41 +370,37 @@ class Test(unittest.TestCase):
                 ],
             },
             'dtype_nested_parent_idx_nml': {
-                'arr': {
-                    'inner': {
-                        'foo': [1.0, 2.0],
-                    },
-                },
+                'arr': [
+                    {'inner': {'foo': 1.0}},
+                    {'inner': {'foo': 2.0}},
+                ],
             },
             'dtype_nested_parent_idx_multi_nml': {
-                'arr': {
-                    'inner': {
-                        'foo': [1.0, 2.0],
-                        'bar': [3.0, 4.0],
-                    },
-                },
+                'arr': [
+                    {'inner': {'foo': 1.0, 'bar': 3.0}},
+                    {'inner': {'foo': 2.0, 'bar': 4.0}},
+                ],
             },
             'dtype_triple_nested_parent_idx_nml': {
-                'arr': {
-                    'a': {
-                        'b': {
-                            'c': [1.0, 2.0],
-                        },
-                    },
-                },
+                'arr': [
+                    {'a': {'b': {'c': 1.0}}},
+                    {'a': {'b': {'c': 2.0}}},
+                ],
             },
             'dtype_mixed_flat_then_nested_nml': {
-                'arr': {
-                    'foo': [1.0, 2.0],
-                    'inner': {
-                        'bar': [3.0, 4.0],
-                    },
-                },
+                'arr': [
+                    {'foo': 1.0, 'inner': {'bar': 3.0}},
+                    {'foo': 2.0, 'inner': {'bar': 4.0}},
+                ],
             },
             'dtype_strided_parent_idx_nml': {
-                'arr': {
-                    'foo': [10.0, None, 30.0, None, 50.0],
-                },
+                'arr': [
+                    {'foo': 10.0},
+                    None,
+                    {'foo': 30.0},
+                    None,
+                    {'foo': 50.0},
+                ],
             },
             'dtype_scatter_partial_nml': {
                 'var': [
@@ -419,16 +419,15 @@ class Test(unittest.TestCase):
             },
             'dtype_scatter_nested_nml': {
                 'var': [
-                    {'x': 1, 'inner': {'foo': [1.0, 2.0]}},
-                    {'x': 2},
+                    {'x': 1, 'inner': {'foo': 1.0}},
+                    {'x': 2, 'inner': {'foo': 2.0}},
                 ],
             },
             'dtype_open_start_parent_idx_nml': {
-                'arr': {
-                    'inner': {
-                        'foo': [1.0, 2.0],
-                    },
-                },
+                'arr': [
+                    {'inner': {'foo': 1.0}},
+                    {'inner': {'foo': 2.0}},
+                ],
             },
             'dtype_positional_gap_nml': {
                 'datum': [['a', 1], None, ['b', 2]],

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -329,6 +329,43 @@ class Test(unittest.TestCase):
                     ['alpha.a', '', '', 'M1', 'target', 6.7, 100.0],
                 ],
             },
+            'dtype_nested_parent_idx_nml': {
+                'arr': {
+                    'inner': {
+                        'foo': [1.0, 2.0],
+                    },
+                },
+            },
+            'dtype_nested_parent_idx_multi_nml': {
+                'arr': {
+                    'inner': {
+                        'foo': [1.0, 2.0],
+                        'bar': [3.0, 4.0],
+                    },
+                },
+            },
+            'dtype_triple_nested_parent_idx_nml': {
+                'arr': {
+                    'a': {
+                        'b': {
+                            'c': [1.0, 2.0],
+                        },
+                    },
+                },
+            },
+            'dtype_mixed_flat_then_nested_nml': {
+                'arr': {
+                    'foo': [1.0, 2.0],
+                    'inner': {
+                        'bar': [3.0, 4.0],
+                    },
+                },
+            },
+            'dtype_strided_parent_idx_nml': {
+                'arr': {
+                    'foo': [10.0, None, 30.0, None, 50.0],
+                },
+            },
         }
 
         self.dtype_case_nml = {

--- a/tests/test_f90nml.py
+++ b/tests/test_f90nml.py
@@ -402,6 +402,37 @@ class Test(unittest.TestCase):
                     'foo': [10.0, None, 30.0, None, 50.0],
                 },
             },
+            'dtype_scatter_partial_nml': {
+                'var': [
+                    {'x': 1},
+                    {'attr': 'a'},
+                    {'attr': 'b'},
+                ],
+            },
+            'dtype_scatter_irregular_nml': {
+                'var': [
+                    {'attr': 'a'},
+                    {'x': 2},
+                    {'attr': 'c'},
+                    {'attr': 'd'},
+                ],
+            },
+            'dtype_scatter_nested_nml': {
+                'var': [
+                    {'x': 1, 'inner': {'foo': [1.0, 2.0]}},
+                    {'x': 2},
+                ],
+            },
+            'dtype_open_start_parent_idx_nml': {
+                'arr': {
+                    'inner': {
+                        'foo': [1.0, 2.0],
+                    },
+                },
+            },
+            'dtype_positional_gap_nml': {
+                'datum': [['a', 1], None, ['b', 2]],
+            },
         }
 
         self.dtype_case_nml = {
@@ -1734,6 +1765,27 @@ class Test(unittest.TestCase):
 
     def test_file_first_grp_no_end_dollar(self):
         self.assertRaises(ValueError, f90nml.read, 'first_grp_no_end_dollar.nml')
+
+    def test_findex_str(self):
+        idx = FIndex(bounds=[(1, 4, 1)])
+        s = str(idx)
+        self.assertIn('FIndex', s)
+        self.assertIn('start=', s)
+
+    def test_join_attr_unexpected_kwarg(self):
+        from f90nml.namelist import _join_attr
+        self.assertRaises(TypeError, _join_attr, 'a', 'b', bogus=1)
+
+    def test_get_array_stride(self):
+        from f90nml.namelist import _get_array_stride
+        # len < 2
+        self.assertIsNone(_get_array_stride([0]))
+        # stride <= 1
+        self.assertIsNone(_get_array_stride([0, 1]))
+        # irregular
+        self.assertIsNone(_get_array_stride([0, 2, 3]))
+        # valid stride
+        self.assertEqual(_get_array_stride([0, 2, 4]), 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Context

Closes #110 
Closes #127 
And maybe others?

f90nml was failing miserably for namelists from this charged particle physics simulation library [Bmad](https://github.com/bmad-sim/bmad-ecosystem), and this PR is the result of my poking around into trying to address that. (See all of the `tao.init` files in that repository, they are all Fortran namelists, many of which fail to parse with the current master)

So this ended up being a big set of changes and fixes. I started out with attempting this entirely manually, but admittedly did get Claude's help here. If that's against your contribution rules, I completely understand! Perhaps it at least can be a basis for a better fix.

If that's still OK, then I expect you might want me to try breaking up this PR into several. I can make an attempt, if there's a greater chance for these changes to get merged.

## Changes / fixes

- Parent-indexed derived-type slice assignment: `arr(1:N)%foo = v1, ..., vN` now parses into `arr.foo = [...]` and round-trips back to the slice form.
- Open-ended parent-indexed bound:
     `var(1:)%ele_name = ... (and var(:N)%...)` 
     gets the bound inferred from the value count instead of crashing/dropping data.
- Single-value open-ended slice:
     `var(1:)%ele_name = 'x'` correctly produces a one-element list
- Sliced field plus per-element field on the same array:
    ```
    var(1:6)%ele_name = ...
    var(1)%low_lim = 0.001
    var(3)%low_lim = 0.001
    ```
- Positional derived-type rows, which can have mixed types:
    ```
    datum(1) = 'a', '', 'M1', 4.5
    ```
- Positional then field on the same index - this is stored as `_positional_row`:
  ```
  design_lattice(1) = 'bmad.lat'
  design_lattice(1)%dynamic_aperture_calc = .true. now keeps both
  ```
     
- Unindexed positional then field:
    ```
    f = 'hello'
    f%x = 42
    ```
- Data getting scattered into different, previously-parsed derived type lists:
     For example, after `var(1)%ele_name, var(2)%ele_name, var(3)%ele_name` are set, a follow-up `var(1:3)%attribute = 'k1', 'k2', 'k3'` distributes values
    into the existing elements rather than overwriting them.
- Nested parent-indexed derived types, along with deeper nesting (hopefully):
     ```
     arr(1:2)%inner%foo = 1.0, 2.0
     ```
- Strided parent index:
     ```
     arr(1:5:2)%foo = 10.0, 30.0, 50.0
     ```
     Parses into `[10, None, 30, None, 50]` and round-trips back to the strided form with a bit of stride detection logic.
- Multi-value indexed assignment:
     ```
     var(N) = v1, v2, ..., vK
     ```
     This is treated as a positional row `N` instead of a flat one-dimensional vector starting at N.
- `FIndex` debug repr: added `__str__` so I could see what was going on with it.

There's additional metadata for keeping track of what's positional, when slicing was used, when parent-based indexing was used. The `"_positional_row"` value is special in the value dictionary, as when you combine positional derived type setting and fieldname-based settings they can clash (... why do people do this and why does Fortran allow it? Ugh.).

The additional metadata helps with round-tripping back to namelist files especially.

I admittedly did not get to testing patching with these, but it's past 5PM on a Friday. So I think that's good enough for now.