### PR TITLE
Scanner update: Character-based; kind-type removal; unit tests

### DIFF
--- a/f90nml/scanner.py
+++ b/f90nml/scanner.py
@@ -101,7 +101,6 @@ for d in (
     {c: 'num_float_e' for c in 'eEdD'},
     {'.': 'num_frac'},
     {c: 'num_float_sign' for c in '+-'},
-    {'_': 'num_kind'},
     {c: 'end' for c in notchar(digit + '+-._eEdD')},
 ):
     M['num'].update(d)
@@ -111,7 +110,6 @@ for d in (
     {c: 'num_frac' for c in digit},
     {c: 'num_float_e' for c in 'eEdD'},
     {c: 'num_float_sign' for c in '+-'},
-    {'_': 'num_kind'},
     {c: 'end' for c in notchar(digit + '+-_eEdD')},
 ):
     M['num_frac'].update(d)
@@ -133,36 +131,9 @@ M['num_float_sign'] = {c: 'num_float_exp' for c in digit}
 M['num_float_exp'] = {}
 for d in (
     {c: 'num_float_exp' for c in digit},
-    {'_': 'num_kind'},
     {c: 'end' for c in notchar(digit + '_')},
 ):
     M['num_float_exp'].update(d)
-
-# Numeric kind token (_)
-M['num_kind'] = {}
-for d in (
-    {c: 'num_kind_name' for c in alpha},
-    {c: 'num_kind_int' for c in digit},
-):
-    M['num_kind'].update(d)
-
-# Numeric kind as a variable name
-# NOTE: This is identical to name, but might be useful for tokenization
-M['num_kind_name'] = {}
-for d in (
-    {c: 'num_kind_name' for c in alnum},
-    {c: 'end' for c in notchar(alnum)},
-):
-    M['num_kind_name'].update(d)
-
-# Numeric kind as coded integer
-# XXX: Why is this alnum?  Shouldn't it be digit?
-M['num_kind_int'] = {}
-for d in (
-    {c: 'num_kind_int' for c in alnum},
-    {c: 'end' for c in notchar(alnum)},
-):
-    M['num_kind_int'].update(d)
 
 # ----
 # Old numeric stuff.. not sure how it holds up
@@ -172,7 +143,6 @@ for d in (
 M['dec'] = {}
 for d in (
     {c: 'num' for c in digit},
-    {'_': 'num_kind'},
     {c: 'op_keyword' for c in notchar('eEdD', ref=alpha)},
     {c: 'op_kw_test' for c in 'eEdD'},
     {c: 'end' for c in notchar(digit + alpha + '_')},

--- a/f90nml/scanner.py
+++ b/f90nml/scanner.py
@@ -59,9 +59,8 @@ for d in (
 ):
     M['blank'].update(d)
 
-# This doesn't actually get used more than once, but it is correct.
 M['cmt'] = {c: 'cmt' for c in notchar('\n')}
-M['cmt']['\n'] = 'end'
+M['cmt']['\n'] = 'blank'
 
 
 # Identifiers (keywords, functions, variables, ...)
@@ -227,16 +226,16 @@ for d in (
     M['op_keyword'].update(d)
 
 
-def scan(file):
+def scan(source):
     lexemes = []
 
     lex = ''
     state = 'start'
 
-    for line in file:
-        linelx = []
-
-        for char in line:
+    # This is the "unit of characters" from the input source.
+    # For files, this is a line.  For strings, this is a character.
+    for unit in source:
+        for char in unit:
             try:
                 state = M[state][char]
             except KeyError:
@@ -246,37 +245,18 @@ def scan(file):
                     # However, non-closed strings are an error
                     raise
 
-            if state not in ('end', 'cmt'):
+            if state != 'end':
                 lex += char
 
-            elif (state == 'end'):
-                linelx.append(lex)
+            else:
+                lexemes.append(lex)
 
                 # Re-evaluate the current token (as a lookback)
                 lex = char
                 state = M['start'][char]
 
-            elif (state == 'cmt'):
-                # Find the index of the first comment character.
-                buf = ''.join(linelx) + lex
-                idx = len(buf[buf.rfind('\n') + 1:])
-
-                # Skip per-character iteration and append the comment as blank.
-                lex += line[idx:]
-                state = 'blank'
-
-                break
-
-        lexemes.extend(linelx)
-
     # Append any trailing lexeme
     if lex:
-        try:
-            assert any('end' in M[state][c] for c in M[state])
-        except AssertionError:
-            print(M[state])
-            raise
-
         lexemes.append(lex)
 
     return lexemes

--- a/f90nml/scanner.py
+++ b/f90nml/scanner.py
@@ -240,9 +240,7 @@ def scan(source):
                 state = M[state][char]
             except KeyError:
                 # This catches potential unicode characters in a string.
-                # TODO: What about non-delimited strings?
-                if state in ('str_a', 'str_q') and char == '\n':
-                    # However, non-closed strings are an error
+                if state not in ('str_a', 'str_q'):
                     raise
 
             if state != 'end':

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,211 @@
+from __future__ import print_function
+
+import os
+import sys
+import unittest
+
+# Include parent path in case we are running within the tests directory
+sys.path.insert(1, '../')
+from f90nml.scanner import scan
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        # Move to test directory if running from setup.py
+        if os.path.basename(os.getcwd()) != 'tests':
+            os.chdir('tests')
+
+    # Names
+
+    def test_blank(self):
+        result = scan('')
+        self.assertEqual([], result)
+
+    def test_whitespace(self):
+        result = scan(' \t\f\r\n')
+        self.assertEqual([' \t\f\r\n'], result)
+
+    # Delimited strings
+
+    def test_name(self):
+        result = scan('abc123')
+        self.assertEqual(['abc123'], result)
+
+    def test_assignment(self):
+        result = scan('a=1')
+        self.assertEqual(['a', '=', '1'], result)
+
+    # Arrays
+
+    def test_array_element(self):
+        result = scan('a(1)')
+        self.assertEqual(['a', '(', '1', ')'], result)
+
+    def test_array_element_multidim(self):
+        result = scan('a(1,2)')
+        self.assertEqual(['a', '(', '1', ',', '2', ')'], result)
+
+    def test_array_section(self):
+        result = scan('a(1:3)')
+        self.assertEqual(['a', '(', '1', ':', '3', ')'], result)
+
+    def test_array_section_whole(self):
+        result = scan('a(:)')
+        self.assertEqual(['a', '(', ':', ')'], result)
+
+    def test_array_section_multidim(self):
+        result = scan('a(1:3,4:6)')
+        self.assertEqual(
+                ['a', '(', '1', ':', '3', ',', '4', ':', '6', ')'],
+                result
+        )
+
+    # Derived types
+
+    def test_derived_type_ref(self):
+        result = scan('a%b')
+        self.assertEqual(['a', '%', 'b'], result)
+
+    # Strings
+
+    def test_string_quote(self):
+        result = scan('"abc"')
+        self.assertEqual(['"abc"'], result)
+
+    def test_string_quote_escape(self):
+        result = scan('"abc""def"')
+        self.assertEqual(['"abc""def"'], result)
+
+    def test_string_apostrophe(self):
+        result = scan("'abc'")
+        self.assertEqual(["'abc'"], result)
+
+    def test_string_apostrophe_escape(self):
+        result = scan("'abc''def'")
+        self.assertEqual(["'abc''def'"], result)
+
+    def test_string_comment_token(self):
+        result = scan('"abc!def"')
+        self.assertEqual(['"abc!def"'], result)
+
+    def test_string_comment_token_newline(self):
+        result = scan('x="abc!def"\n')
+        self.assertEqual(['x', '=', '"abc!def"', '\n'], result)
+
+    def test_non_delimited_string_quote(self):
+        result = scan('abc"def"')
+        self.assertEqual(['abc"def"'], result)
+
+    # Scalars
+
+    def test_integer(self):
+        result = scan('123')
+        self.assertEqual(['123'], result)
+
+    def test_integer_negate(self):
+        result = scan('-123')
+        self.assertEqual(['-123'], result)
+
+    def test_integer_positive(self):
+        result = scan('+123')
+        self.assertEqual(['+123'], result)
+
+    def test_real_decimal(self):
+        result = scan('1.23')
+        self.assertEqual(['1.23'], result)
+
+    def test_real_leading_decimal(self):
+        result = scan('.12')
+        self.assertEqual(['.12'], result)
+
+    def test_real_signed_leading_decimal(self):
+        result = scan('-.12')
+        self.assertEqual(['-.12'], result)
+
+    # Exponent form
+
+    def test_real_e(self):
+        result = scan('1e3')
+        self.assertEqual(['1e3'], result)
+
+    def test_real_e_decimal(self):
+        result = scan('1.2e3')
+        self.assertEqual(['1.2e3'], result)
+
+    def test_real_d(self):
+        result = scan('1D3')
+        self.assertEqual(['1D3'], result)
+
+    def test_real_d_signed_exp(self):
+        result = scan('-1.2D+3')
+        self.assertEqual(['-1.2D+3'], result)
+
+    # The hideous no-exponent reals!
+    def test_real_no_e(self):
+        result = scan('1.2-3')
+        self.assertEqual(['1.2-3'], result)
+
+    def test_real_positive_no_e(self):
+        result = scan('1.2+3')
+        self.assertEqual(['1.2+3'], result)
+
+    def test_positive_inf(self):
+        result = scan('+inf')
+        self.assertEqual(['+inf'], result)
+
+    def test_negative_nan(self):
+        result = scan('-nan')
+        self.assertEqual(['-nan'], result)
+
+    # Logicals and keyword operators
+
+    def test_logical_true(self):
+        result = scan('.true.')
+        self.assertEqual(['.true.'], result)
+
+    def test_logical_false(self):
+        result = scan('.false.')
+        self.assertEqual(['.false.'], result)
+
+    def test_keyword_operator(self):
+        result = scan('.not.')
+        self.assertEqual(['.not.'], result)
+
+    # Repeat values
+
+    def test_repeat_value(self):
+        result = scan('2*1.0')
+        self.assertEqual(['2', '*', '1.0'], result)
+
+    # Comments
+
+    def test_comment_line(self):
+        result = scan('!comment\n')
+        self.assertEqual(['!comment\n'], result)
+
+    def test_comment_after_value(self):
+        result = scan('x=1!comment')
+        self.assertEqual(['x', '=', '1', '!comment'], result)
+
+    def test_comment_after_value_newline(self):
+        result = scan('x=1!comment\n/')
+        self.assertEqual(['x', '=', '1', '!comment\n', '/'], result)
+
+    def test_comment_after_blank_newline(self):
+        result = scan('x=1 !comment\n/')
+        self.assertEqual(['x', '=', '1', ' !comment\n', '/'], result)
+
+    def test_comment_after_string(self):
+        result = scan('x="abc"!comment\n')
+        self.assertEqual(['x', '=', '"abc"', '!comment\n'], result)
+
+    def test_comment_in_group(self):
+        result = scan('&grp\n  x=1!comment\n/\n')
+        self.assertEqual(
+            ['&', 'grp', '\n  ', 'x', '=', '1', '!comment\n', '/', '\n'],
+            result
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -110,6 +110,9 @@ class Test(unittest.TestCase):
         result = scan('+123')
         self.assertEqual(['+123'], result)
 
+    def test_integer_kind(self):
+        self.assertRaises(KeyError, scan, '1_8')
+
     def test_real_decimal(self):
         result = scan('1.23')
         self.assertEqual(['1.23'], result)
@@ -121,6 +124,12 @@ class Test(unittest.TestCase):
     def test_real_signed_leading_decimal(self):
         result = scan('-.12')
         self.assertEqual(['-.12'], result)
+
+    def test_real_decimal_kind(self):
+        self.assertRaises(KeyError, scan, '1.0_8')
+
+    def test_real_leading_decimal_kind(self):
+        self.assertRaises(KeyError, scan, '.1_8')
 
     # Exponent form
 
@@ -139,6 +148,9 @@ class Test(unittest.TestCase):
     def test_real_d_signed_exp(self):
         result = scan('-1.2D+3')
         self.assertEqual(['-1.2D+3'], result)
+
+    def test_real_exponent_kind(self):
+        self.assertRaises(KeyError, scan, '1e3_8')
 
     # The hideous no-exponent reals!
     def test_real_no_e(self):


### PR DESCRIPTION
This is a minor update to the scanner parser:
* The main loop is now character-based, rather than line-based, which is in closer alignment with namelist parsing.  Files will still default to line-based units, although this is not recognized in-loop.
* Kind-parsing has been eliminated, since these are not supported in namelists.
* Handling of Unicode characters (or, more accurately, anything unspecified in the machine) has been simplified to handle 
* Independent scanner unit tests have been implemented.